### PR TITLE
Fix path to renamed Fortran_test in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,8 @@ if(CGNS_ENABLE_FORTRAN)
     if (CMAKE_Fortran_COMPILER_WORKS)
       foreach(nc ${F2CLIST})
         try_compile(NAMING_TEST_RESULT
-	    "${CMAKE_BINARY_DIR}/fortran_test"
-	    "${CMAKE_SOURCE_DIR}/fortran_test"
+	    "${CMAKE_BINARY_DIR}/Fortran_test"
+	    "${CMAKE_SOURCE_DIR}/Fortran_test"
 	    projectName ${nc})
         if(${NAMING_TEST_RESULT} STREQUAL "TRUE")
           set(FORTRAN_NAMING "${nc}" CACHE STRING ${FORTRAN_NAMING_HELP})


### PR DESCRIPTION
Avoid getting errors similar to this from cmake when FORTRAN_NAMING variable is undefined:
CMake Error: The source directory "/u/michal/Flacs_workspace/CGNS/Source/fortran_test" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
CMake Error: Internal CMake error, TryCompile configure of cmake failed
-- Trying Fortran naming convention UPPERCASE__: failure