### PR TITLE
Fixes for CGNS-83: Large files fail on 64-bit windows

### DIFF
--- a/src/cgnstypes.h.in
+++ b/src/cgnstypes.h.in
@@ -37,6 +37,9 @@
 #define CG_MAX_INT32 0x7FFFFFFF
 #ifdef _WIN32
 # define CG_LONG_T __int64
+#ifdef CG_BUILD_64BIT
+#define stat _stat32i64
+#endif
 #else
 # define CG_LONG_T @CGLONGT@
 #endif

--- a/src/configure.bat
+++ b/src/configure.bat
@@ -971,7 +971,14 @@ echo #define CG_BUILD_SCOPE  %doscope% >> cgnstypes.h
 echo #define CG_BUILD_BASESCOPE  %dobasescope% >> cgnstypes.h
 echo.>> cgnstypes.h
 echo #define CG_MAX_INT32 0x7FFFFFFF>> cgnstypes.h
+echo #ifdef _WIN32>> cgnstypes.h
 echo #define CG_LONG_T    __int64>> cgnstypes.h
+echo #ifdef CG_BUILD_64BIT>> cgnstypes.h
+echo #define stat _stat32i64>> cgnstypes.h
+echo #endif>> cgnstypes.h
+echo #else>> cgnstypes.h
+echo # define CG_LONG_T long long>> cgnstypes.h
+echo #endif>> cgnstypes.h
 echo.>> cgnstypes.h
 echo #if CG_BUILD_LEGACY>> cgnstypes.h
 echo # define CG_SIZEOF_SIZE    32 >> cgnstypes.h


### PR DESCRIPTION
The problem is that the incorrect _stat_ implementation was used; instead of `_stat32i64` it defaults to `_stat64i32` (VS2010/x64). By re-defining _stat_ to `_stat32i64` in cgnstypes.h (that is, in the CMake .in file and in the configure.bat file), this problem is solved and files larger than 2^32-1 bytes can be opened.