### PR TITLE
Add missing include path

### DIFF
--- a/src/cgnstools/tkogl/CMakeLists.txt
+++ b/src/cgnstools/tkogl/CMakeLists.txt
@@ -2,7 +2,7 @@
 # tkogl #
 #########
 
-include_directories(${TCL_INCLUDE_PATH} ${TK_INCLUDE_PATH})
+include_directories(${TCL_INCLUDE_PATH} ${TK_INCLUDE_PATH} ${OPENGL_INCLUDE_DIR})
 
 set(tkogl_FILES 
 	tkogl.c


### PR DESCRIPTION
CMake-based build of tkogl was missing include path for opengl headers.  Not sure this is the correct fix, but it eliminates this and several other errors about not being able to find GL/gl.h
