### PR TITLE
Add missing dependency in cgns_to_plot3d (cmake build)

### DIFF
--- a/src/cgnstools/utilities/CMakeLists.txt
+++ b/src/cgnstools/utilities/CMakeLists.txt
@@ -59,6 +59,7 @@ add_dependencies(plot3d_to_cgns cgns_static calclib)
 set(cgns_to_plot3d_FILES 
 	cgns_to_plot3d.c
 	cgnsutil.c
+	binaryio.c
 	../common/getargs.c
 	p3dfout.c)
 


### PR DESCRIPTION
binaryio.c is needed to resolve bf_machname symbol referenced from OPENF in p3dfout.c