### PR TITLE
Fix incorrect structured field array access -- cut paste error

### DIFF
--- a/src/cgnstools/utilities/cgnsutil.c
+++ b/src/cgnstools/utilities/cgnsutil.c
@@ -1744,7 +1744,7 @@ void write_solution_field (int nz, int ns, int nf)
         if (f->exptype == CGNS_ENUMV(RealSingle)) {
             float exp[5];
             for (n = 0; n < 5; n++)
-                exp[n] = (float)f->dataconv[n];
+                exp[n] = (float)f->exponent[n];
             if (cg_goto (cgnsfn, cgnsbase, "Zone_t", z->id,
                 "FlowSolution_t", s->id, "DataArray_t", f->id, "end") ||
                 cg_exponents_write (CGNS_ENUMV(RealSingle), exp))


### PR DESCRIPTION
The conversion from double to real was accessing an incorrect array -- dataconv instead of exponent.  This was also causing invalid memory accesses.  Looks like cut/paste error using code from line 1731 and not updating the structure field being accessed.