### PR TITLE
Fix c_double_eq function

### DIFF
--- a/src/ptests/benchmark_hdf5.c
+++ b/src/ptests/benchmark_hdf5.c
@@ -131,7 +131,7 @@ int c_double_eq(double a, double b) {
 
   double eps = 1.e-8;
 
-  if(a-b < eps) {
+  if(fabs(a-b) < eps) {
     return true;
   }
   return false;


### PR DESCRIPTION
The c_double_eq function needs an absolute value of the difference.  The current test of "a-b < eps" will return true whenever a is less than b.  For example, c_double_eq(1,10) will return true since 1-10 == -9 which is less than eps.  

Function could also be shortened to "return (fabs(a-b) < eps);"