### PR TITLE
Fix to avoid hang due to collective requirement

### DIFF
--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -430,11 +430,13 @@ int cgp_elements_write_data(int fn, int B, int Z, int S, cgsize_t start,
     section = cgi_get_section(cg, B, Z, S);
     if (section == 0 || section->connect == 0) return CG_ERROR;
 
-    if (start > end ||
-        start < section->range[0] ||
-        end > section->range[1]) {
-	cgi_error("Error in requested element data range.");
-        return CG_ERROR;
+    if (elements) {
+    	if (start > end ||
+            start < section->range[0] ||
+            end > section->range[1]) {
+	    cgi_error("Error in requested element data range.");
+            return CG_ERROR;
+        }    
     }
     if (!IS_FIXED_SIZE(section->el_type)) {
         cgi_error("element must be a fixed size for parallel IO");
@@ -475,11 +477,13 @@ int cgp_elements_read_data(int fn, int B, int Z, int S, cgsize_t start,
     section = cgi_get_section(cg, B, Z, S);
     if (section == 0 || section->connect == 0) return CG_ERROR;
 
-    if (start > end ||
-        start < section->range[0] ||
-        end > section->range[1]) {
-	cgi_error("Error in requested element data range.");
-        return CG_ERROR;
+    if (elements) { /* A processor may have nothing to read */
+    	if (start > end ||
+            start < section->range[0] ||
+            end > section->range[1]) {
+	   cgi_error("Error in requested element data range.");
+           return CG_ERROR;
+        }
     }
     if (!IS_FIXED_SIZE(section->el_type)) {
         cgi_error("element must be a fixed size for parallel IO");


### PR DESCRIPTION
If this zone has no elements on this processor, then it must still call `cgp_elements_read_data` or `cgp_elements_write_data` in order for the collectives down in the HDF5 library to work correctly (calls an MPI_Allreduce and possibly other collectives). Therefore, only check for valid data range if the 'elements' pointer is non-null.

This is similar to what is done in `cgp_coord_write_data` and `cgp_coord_read_data` at lines 369 and 320.