### PR TITLE
Initialize err, add missing return

### DIFF
--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -563,7 +563,7 @@ int cgio_check_file (const char *filename, int *file_type)
     static char *HDF5sig = "\211HDF\r\n\032\n";
     struct stat st;
 
-    int mpibuf[2], err;
+    int mpibuf[2], err = CGIO_ERR_NONE;
 
     if (ACCESS (filename, 0) || stat (filename, &st) ||
         S_IFREG != (st.st_mode & S_IFREG)) {
@@ -585,6 +585,7 @@ int cgio_check_file (const char *filename, int *file_type)
 	} else {
 	  err = set_error(CGIO_ERR_FILE_OPEN);
 	}
+	return err;
       }
     fread (buf, 1, sizeof(buf), fp);
     buf[sizeof(buf)-1] = 0;


### PR DESCRIPTION
err is possibly used unintialized in test "if(err == set_error(CGIO_ERR_NONE)) return err;" around line 618.  

At line 582, fp is checked and if it is NULL, then error codes are set.  However, execution then falls out of the if NULL test and then fp is used in the fread function at line 589.  It looks like there should maybe be a "return err" at the end of the NULL test.

(Both of these found by coverity)