### PR TITLE
Error code was not set correctly.

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -1424,6 +1424,7 @@ void ADFH_Configure(const int option, const void *value, int *err)
       }
       else {
         ParallelMPICommunicator = (MPI_Comm)value;
+	set_error(NO_ERROR, err);
       }
     }
 #endif


### PR DESCRIPTION
ADFH_Configure did not set error code if option was ADFH_CONFIG_MPI_COMM.

Note that I set it to NO_ERROR to follow guidance of the ADFH_CONFIG_COMPRESS branch, but NO_ERROR seems to be different from CG_OK.  Should successful return be CG_OK or NO_ERROR?

The return value of ADFH_Configure is returned unchanged from cgp_mpi_comm, so cgp_mpi_comm is returning a -1 instead of CG_OK.