### PR TITLE
CGNS-85 fix,

### DIFF
--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -47,6 +47,7 @@ char hdf5_access[64] = "NATIVE";
 #endif
 #ifdef BUILD_PARALLEL
 #include <mpi.h>
+MPI_Comm pcg_mpi_comm=MPI_COMM_WORLD;
 int pcg_mpi_comm_size;
 int pcg_mpi_comm_rank;
 int pcg_mpi_initialized;
@@ -610,7 +611,7 @@ int cgio_check_file (const char *filename, int *file_type)
     if(pcg_mpi_initialized) {
       mpibuf[0] = err;
       mpibuf[1] = *file_type;
-      MPI_Bcast(mpibuf, 2, MPI_INT, 0, MPI_COMM_WORLD);
+      MPI_Bcast(mpibuf, 2, MPI_INT, 0, pcg_mpi_comm);
       err = mpibuf[0];
       *file_type = mpibuf[1];
     }

--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -37,6 +37,7 @@ freely, subject to the following restrictions:
 
 /* MPI-2 info object */
 extern MPI_Info pcg_mpi_info;
+extern MPI_Comm pcg_mpi_comm;
 extern int pcg_mpi_comm_size;
 extern int pcg_mpi_comm_rank;
 /* Flag indicating if HDF5 file accesses is PARALLEL or NATIVE */
@@ -213,6 +214,7 @@ static int check_parallel(cgns_file *cgfile)
 
 int cgp_mpi_comm(MPI_Comm comm)
 {
+    pcg_mpi_comm=comm;
     return cgio_configure(CG_CONFIG_HDF5_MPI_COMM, (void *)(comm));
 }
 
@@ -259,8 +261,8 @@ int cgp_open(const char *filename, int mode, int *fn)
     int ierr, old_type = cgns_filetype;
 
 
-    MPI_Comm_rank(MPI_COMM_WORLD, &pcg_mpi_comm_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &pcg_mpi_comm_size);
+    MPI_Comm_rank(pcg_mpi_comm, &pcg_mpi_comm_rank);
+    MPI_Comm_size(pcg_mpi_comm, &pcg_mpi_comm_size);
 
     /* Flag is true if MPI_Init or MPI_Init_thread has been called and false otherwise. */
     pcg_mpi_initialized = 0;


### PR DESCRIPTION
 cgp_open now uses current communicator, defined by cgp_mpi_comm.

Hi, I ran into CGNS-85 also in the case of a MPMD program where rank 0 in MPI_COMM_WORLD was not involved in opening the file.
Here is the fix I propose, similar to the one described in the CGNS-85 issue. 
Basically, the communicator used when calling cgp_mpi_comm is saved and reused for cgp_open and cgio_check_file.