### PR TITLE
Spelling error in function name

### DIFF
--- a/src/cgnstools/common/hash.c
+++ b/src/cgnstools/common/hash.c
@@ -211,7 +211,7 @@ size_t HashList (HASH hash, size_t (*listentry)(void *entry, void *userdata),
 #define MAXINT  ((size_t) ~ 0)
 #define MAXLEN  128
 
-void HastStats (HASH hash)
+void HashStats (HASH hash)
 {
     HASH_TAB *tabp = (HASH_TAB *)hash;
     BUCKET *p;

--- a/src/tools/hash.c
+++ b/src/tools/hash.c
@@ -211,7 +211,7 @@ size_t HashList (HASH hash, size_t (*listentry)(void *entry, void *userdata),
 #define MAXINT  ((size_t) ~ 0)
 #define MAXLEN  128
 
-void HastStats (HASH hash)
+void HashStats (HASH hash)
 {
     HASH_TAB *tabp = (HASH_TAB *)hash;
     BUCKET *p;


### PR DESCRIPTION
This corrects spelling mistake in `HashStats()` function in two different files. I discovered this while trying to use the function but got linker errors.

PS: This same file is present in **two** different directories. Code should be modified to use one of those & delete the other file. This will help code maintenance. I can send another pull request for that change if that change is desired.