### PR TITLE
Add prototype for cgp_parent_data_write function

### DIFF
--- a/src/pcgnslib.h
+++ b/src/pcgnslib.h
@@ -82,6 +82,8 @@ CGNSDLL int cgp_elements_write_data(int fn, int B, int Z, int S,
     cgsize_t start, cgsize_t end, const cgsize_t *elements);
 CGNSDLL int cgp_elements_read_data(int fn, int B, int Z, int S,
     cgsize_t start, cgsize_t end, cgsize_t *elements);
+CGNSDLL int cgp_parent_data_write(int fn, int B, int Z, int S,
+    cgsize_t start, cgsize_t end, const cgsize_t *parent_data);
 
 /*===== Solution IO Prototypes =====*/
 


### PR DESCRIPTION
A first shot at an implementation for cgp_parent_data_write.  It works in the testing I have done on my local project, but not sure if the "style" is correct.  It currently uses an MPI_Allreduce call to determine the total size of the ParentElements and ParentElementsPosition nodes which are created during the function. It might be cleaner to have two functions -- one to create the nodes and one to write the data to the nodes, but this implementation follows the behavior of the serial version.

Let me know what you think and I will modify as needed.

(This also needs the pcgnslib.h changes in patch-16; sorry for the screwy pull request but the method I usually use was creating very noisy patch...)