### PR TITLE
Check for Fortran concatenation setting in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -295,6 +295,21 @@ if (CHECK_FORTRAN_95)
 endif (CHECK_FORTRAN_95)
 endif (HAVE_FORTRAN_2003)
 
+CHECK_FORTRAN_FEATURE(FortranConcat
+  "
+# define CONCATENATE(a,b) a##b
+      CONCATENATE(PRO,GRAM) testconcat
+         IMPLICIT NONE
+          integer a
+          a = 10
+      END PROGRAM testconcat
+  "
+  CHECK_FORTRAN_CONCAT
+)
+if (NOT CHECK_FORTRAN_CONCAT)
+ SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DNO_CONCATENATION")
+endif (NOT CHECK_FORTRAN_CONCAT)
+
 endif (BUILDFORTRAN)
 
 macro(native_paths INPUT_PATH_VARIABLE RESULT_VARIABLE)


### PR DESCRIPTION
Determine which fortran concatenation macro to use in a CMake-based build.
Checks whether the a##b mode works; if not, then assumes that the IDENTITY(a)b mode works.

This is used in cgnstypes_f03.h