### PR TITLE
Implementation and test for cgp_parent_data_write

### DIFF
--- a/src/configure.bat
+++ b/src/configure.bat
@@ -2601,6 +2601,7 @@ echo 	benchmark$(EXE) \>> ptests\Makefile
 echo 	open_close$(EXE) \>> ptests\Makefile
 echo 	test_base$(EXE) \>> ptests\Makefile
 echo 	test_unstructured$(EXE) \>> ptests\Makefile
+echo 	test_unstruc_quad$(EXE) \>> ptests\Makefile
 echo 	test_zone$(EXE) \>> ptests\Makefile
 echo 	thesis_benchmark$(EXE)>> ptests\Makefile
 echo FALL =	ftest$^(EXE^)>> ptests\Makefile
@@ -2625,6 +2626,7 @@ echo 	-@runptest.bat $(MPIEXEC) benchmark$(EXE)>> ptests\Makefile
 echo 	-@runptest.bat $(MPIEXEC) open_close$(EXE)>> ptests\Makefile
 echo 	-@runptest.bat $(MPIEXEC) test_base$(EXE)>> ptests\Makefile
 echo 	-@runptest.bat $(MPIEXEC) test_unstructured$(EXE)>> ptests\Makefile
+echo 	-@runptest.bat $(MPIEXEC) test_unstruc_quad$(EXE)>> ptests\Makefile
 echo 	-@runptest.bat $(MPIEXEC) test_zone$(EXE)>> ptests\Makefile
 echo 	-@runptest.bat $(MPIEXEC) thesis_benchmark$(EXE)>> ptests\Makefile
 if not "%f2c%" == "none" (
@@ -2661,6 +2663,9 @@ echo #---------->> ptests\Makefile
 echo.>> ptests\Makefile
 echo test_unstructured$(EXE) : test_unstructured.c $(CGNSLIB)>> ptests\Makefile
 echo 	$(CC) $(COPTS) $(CEOUT)$@ test_unstructured.c $(LDLIBS) $(CLIBS)>> ptests\Makefile
+echo.>> ptests\Makefile
+echo test_unstruc_quad$(EXE) : test_unstruc_quad.c $(CGNSLIB)>> ptests\Makefile
+echo 	$(CC) $(COPTS) $(CEOUT)$@ test_unstruc_quad.c $(LDLIBS) $(CLIBS)>> ptests\Makefile
 echo.>> ptests\Makefile
 echo #---------->> ptests\Makefile
 echo.>> ptests\Makefile

--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -507,6 +507,119 @@ int cgp_elements_read_data(int fn, int B, int Z, int S, cgsize_t start,
 			      1, &rmin, &rmax, &Data, CG_PAR_READ);
 }
 
+int cgp_parent_data_write(int fn, int B, int Z, int S,
+			  cgsize_t start, cgsize_t end,
+			  const cgsize_t *parent_data)
+{
+    cgns_section *section;
+    cgsize_t *data, i, j, n;
+    hid_t hid;
+    cgsize_t rmin[2], rmax[2];
+    CGNS_ENUMT(DataType_t) type;
+
+     /* get file and check mode */
+    cg = cgi_get_file(fn);
+    if (cg == 0) return CG_ERROR;
+
+    if (cgi_check_mode(cg->filename, cg->mode, CG_MODE_WRITE))
+      return CG_ERROR;
+
+    section = cgi_get_section(cg, B, Z, S);
+    if (section == 0) return CG_ERROR;
+
+    /* check input range */
+    if (parent_data) {
+      if (start > end ||
+	  start < section->range[0] ||
+	  end > section->range[1]) {
+	cgi_error("Error in requested element data range.");
+	return CG_ERROR;
+      }    
+    }
+
+    if (!IS_FIXED_SIZE(section->el_type)) {
+        cgi_error("element must be a fixed size for parallel IO");
+        return CG_ERROR;
+    }
+
+    /* ParentElements ... */
+    if (section->parelem) {
+        if (cg->mode == CG_MODE_WRITE) {
+            cgi_error("ParentElements is already defined under Elements_t '%s'",
+                   section->name);
+            return CG_ERROR;
+        }
+        if (cgi_delete_node(section->id, section->parelem->id))
+            return CG_ERROR;
+        cgi_free_array(section->parelem);
+        memset(section->parelem, 0, sizeof(cgns_array));
+    } else {
+        section->parelem = CGNS_NEW(cgns_array, 1);
+    }
+
+    /* Get total size across all processors */
+    cgsize_t num = end == 0 ? 0 : end - start + 1;
+    num = num < 0 ? 0 : num;
+    MPI_Datatype mpi_type = sizeof(cgsize_t) == 32 ? MPI_INT : MPI_LONG_LONG_INT;
+    MPI_Allreduce(MPI_IN_PLACE, &num, 1, mpi_type, MPI_SUM, MPI_COMM_WORLD);
+
+    strcpy(section->parelem->data_type, CG_SIZE_DATATYPE);
+    section->parelem->data_dim = 2;
+    section->parelem->dim_vals[0] = num;
+    section->parelem->dim_vals[1] = 2;
+    strcpy(section->parelem->name, "ParentElements");
+
+    if (cgi_write_array(section->id, section->parelem)) return CG_ERROR;
+
+    /* ParentElementsPosition ... */
+    if (section->parface) {
+        if (cg->mode==CG_MODE_WRITE) {
+            cgi_error("ParentElementsPosition is already defined under Elements_t '%s'",
+                   section->name);
+            return CG_ERROR;
+        }
+        if (cgi_delete_node(section->id, section->parface->id))
+            return CG_ERROR;
+        cgi_free_array(section->parface);
+        memset(section->parface, 0, sizeof(cgns_array));
+    } else {
+        section->parface = CGNS_NEW(cgns_array, 1);
+    }
+
+    strcpy(section->parface->data_type, CG_SIZE_DATATYPE);
+    section->parface->data_dim = 2;
+    section->parface->dim_vals[0] = num;
+    section->parface->dim_vals[1] = 2;
+    strcpy(section->parface->name, "ParentElementsPosition");
+
+    if (cgi_write_array(section->id, section->parface)) return CG_ERROR;
+
+    /* ParentElements -- write data */
+    rmin[0] = start - section->range[0] + 1;
+    rmax[0] = end - section->range[0] + 1;
+    rmin[1] = 1;
+    rmax[1] = 2;
+    type = cgi_datatype(section->parelem->data_type);
+
+    cg_rw_t Data;
+    Data.u.wbuf = parent_data;
+
+    to_HDF_ID(section->parelem->id, hid);
+    int herr = readwrite_data_parallel(hid, type, 2, rmin, rmax, &Data, CG_PAR_WRITE);
+    if (herr != CG_OK)
+      return herr;
+
+    /* ParentElementsPosition -- data follows ParentElements data */
+    type = cgi_datatype(section->parface->data_type);
+
+    if (parent_data) {
+      cgsize_t delta = rmax[0] - rmin[0] + 1;
+      Data.u.wbuf = &parent_data[2*delta];
+    }
+    to_HDF_ID(section->parface->id, hid);
+    return readwrite_data_parallel(hid, type, 2, rmin, rmax, &Data, CG_PAR_WRITE);
+}
+
 /*===== Solution IO Prototypes ============================*/
 
 int cgp_field_write(int fn, int B, int Z, int S,

--- a/src/pcgnslib.h
+++ b/src/pcgnslib.h
@@ -83,6 +83,10 @@ CGNSDLL int cgp_elements_write_data(int fn, int B, int Z, int S,
 CGNSDLL int cgp_elements_read_data(int fn, int B, int Z, int S,
     cgsize_t start, cgsize_t end, cgsize_t *elements);
 
+CGNSDLL int cgp_parent_data_write(int fn, int B, int Z, int S,
+				  cgsize_t start, cgsize_t end,
+				  const cgsize_t *parent_data);
+
 /*===== Solution IO Prototypes =====*/
 
 CGNSDLL int cgp_field_write(int fn, int B, int Z, int S,

--- a/src/ptests/CMakeLists.txt
+++ b/src/ptests/CMakeLists.txt
@@ -43,6 +43,9 @@ add_executable(test_base ${test_base_FILES})
 set(test_unstructured_FILES test_unstructured.c)
 add_executable(test_unstructured ${test_unstructured_FILES})
 
+set(test_unstruc_quad_FILES test_unstruc_quad.c)
+add_executable(test_unstruc_quad ${test_unstruc_quad_FILES})
+
 set(test_zone_FILES test_zone.c)
 add_executable(test_zone ${test_zone_FILES})
 
@@ -74,6 +77,8 @@ if (CGNS_ENABLE_TESTS)
       ${MPIEXEC_PREFLAGS} ./test_base ${MPIEXEC_POSTFLAGS})
   add_test(test_unstructured ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} "2"
       ${MPIEXEC_PREFLAGS} ./test_unstructured ${MPIEXEC_POSTFLAGS})
+  add_test(test_unstruc_quad ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} "2"
+      ${MPIEXEC_PREFLAGS} ./test_unstruc_quad ${MPIEXEC_POSTFLAGS})
   add_test(test_zone ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} "2"
       ${MPIEXEC_PREFLAGS} ./test_zone ${MPIEXEC_POSTFLAGS})
   add_test(thesis_benchmark ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} "2"

--- a/src/ptests/Makefile.in
+++ b/src/ptests/Makefile.in
@@ -20,6 +20,7 @@ CALL =	pcgns_ctest$(EXE) \
 	open_close$(EXE) \
 	test_base$(EXE) \
 	test_unstructured$(EXE) \
+	test_unstruc_quad$(EXE) \
 	test_zone$(EXE) \
 	thesis_benchmark$(EXE)
 
@@ -87,6 +88,12 @@ test_base$(EXE) : test_base.c $(CGNSLIB)
 
 test_unstructured$(EXE) : test_unstructured.c $(CGNSLIB)
 	$(CC) $(COPTS) $(CEOUT)$@ test_unstructured.c $(LDLIBS) $(CLIBS)
+	$(STRIP) $@
+
+#----------
+
+test_unstruc_quad$(EXE) : test_unstruc_quad.c $(CGNSLIB)
+	$(CC) $(COPTS) $(CEOUT)$@ test_unstruc_quad.c $(LDLIBS) $(CLIBS)
 	$(STRIP) $@
 
 #----------

--- a/src/ptests/test_unstruc_quad.c
+++ b/src/ptests/test_unstruc_quad.c
@@ -1,0 +1,193 @@
+/*
+! @file test_unstruc_quad.c
+! @author Greg Sjaardema <gsjaardema@gmail.com>
+! @version 0.1
+!
+! @section LICENSE
+! BSD style license
+!
+! @section DESCRIPTION
+! Test program for pcgns library
+! -- Created to test cgp_parent_data_write function
+! -- Based on test_unstructured.c
+*/
+
+/*
+
+2....4....6....8 8...10...12...14 14...16...18...20 L+1.L+3...L+5...L+7
+|    |    |    | |    |    |    | |     |    |    | |     |     |     |
+1....3....5....7 7....9...11...13 13...15...17...19 L...L+2...L+4...L+6
+   1    2   3      4    5    6       7    8    9      M     M+1   M+2
+       P0               P1                P2             PN
+
+L = P*6+1   M = P*3+1
+The BC "Bottom" is on the bottom (y=0) edge of the mesh.
+The BC "Left"   is on the left (x=0) edge of the mesh.
+ -- included to test whether works with 0 entries on some procs.
+*/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "pcgnslib.h"
+#include "mpi.h"
+
+#define cgp_doError {printf("Error at %s:%u\n",__FILE__, __LINE__); return 1;}
+
+int main(int argc, char* argv[]) {
+  int err;
+  int comm_size;
+  int comm_rank;
+  MPI_Info info;
+  int fn;
+  int B;
+  int Z;
+  int S;
+  int Cx,Cy,Cz;
+  int cell_dim = 3;
+  int phys_dim = 3;
+  cgsize_t nijk[3], min, max;
+  int k, vert_proc;
+  double *x, *y, *z;
+  int nelem, nvert;
+  cgsize_t start, end, emin, emax, *elements;
+  cgsize_t *el_ptr = NULL;
+
+  err = MPI_Init(&argc,&argv);
+  if(err!=MPI_SUCCESS) cgp_doError;
+  err = MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+  if(err!=MPI_SUCCESS) cgp_doError;
+  err = MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank);
+  if(err!=MPI_SUCCESS) cgp_doError;
+  err = MPI_Info_create(&(info));
+  if(err!=MPI_SUCCESS) cgp_doError;
+
+  nelem = 3 * comm_size;
+  nvert = 2 * nelem + 2;
+  nijk[0] = nvert;
+  nijk[1] = nelem;
+  nijk[2] = 0;
+
+
+  if (cgp_open("test_unstruc_quad.cgns", CG_MODE_WRITE, &fn) ||
+      cg_base_write(fn, "Base 1", cell_dim, phys_dim, &B) ||
+      cg_zone_write(fn, B, "Zone 1", nijk, CGNS_ENUMV(Unstructured), &Z))
+    cgp_error_exit();
+
+  vert_proc = 8;
+  x = (double *)malloc(vert_proc*sizeof(double));
+  y = (double *)malloc(vert_proc*sizeof(double));
+  z = (double *)malloc(vert_proc*sizeof(double));
+
+  min = 6*comm_rank+1;
+  max = min+7;
+
+  for(k=0;k<vert_proc;k+=2) {
+    x[k+0] = (double) (min+k);
+    x[k+1] = (double) (min+k);
+    y[k+0] = 0.0;
+    y[k+1] = 1.0;
+    z[k+0] = 0.0;
+    z[k+1] = 0.0;
+  }
+
+  if (cgp_coord_write(fn,B,Z,CGNS_ENUMV(RealDouble),"CoordinateX",&Cx) ||
+      cgp_coord_write(fn,B,Z,CGNS_ENUMV(RealDouble),"CoordinateY",&Cy) ||
+      cgp_coord_write(fn,B,Z,CGNS_ENUMV(RealDouble),"CoordinateZ",&Cz))
+    cgp_error_exit();
+
+  if (cgp_coord_write_data(fn,B,Z,Cx,&min,&max,x) ||
+      cgp_coord_write_data(fn,B,Z,Cy,&min,&max,y) ||
+      cgp_coord_write_data(fn,B,Z,Cz,&min,&max,z))
+    cgp_error_exit();
+
+  start = 1;
+  end = comm_size*3;
+  if (cgp_section_write(fn,B,Z,"Elements",CGNS_ENUMV(QUAD_4),start,end,0,&S))
+    cgp_error_exit();
+
+  nelem = 3;
+  printf("%d:%d\n",comm_rank,nelem);
+  emin = comm_rank*3+1;
+  emax = emin+2;
+
+  elements = (cgsize_t *)malloc(nelem*4*sizeof(cgsize_t));
+  for(k=0;k<nelem;k++) {
+    elements[4*k+0] = 2*(emin+k)-1;
+    elements[4*k+1] = 2*(emin+k)+1;
+    elements[4*k+2] = 2*(emin+k)+2;
+    elements[4*k+3] = 2*(emin+k)+0;
+  }
+  printf("%d:%d %d %d\n",comm_rank,nelem,(int)emin,(int)emax);
+
+  if (cgp_elements_write_data(fn,B,Z,S,emin,emax,elements))
+    cgp_error_exit();
+
+  start = 3*comm_size + 1;
+  end   = start + 3*comm_size - 1;
+  if (cgp_section_write(fn,B,Z,"Bottom",CGNS_ENUMV(BAR_2),start,end,0,&S))
+    cgp_error_exit();
+
+  /* Parent Element/Side data */
+  for(k=0; k < 3; k++) {
+    elements[3*0 + k] = comm_rank*3+1+k; /* Element */
+    elements[3*1 + k] = 0;
+    elements[3*2 + k] = 1; /* Side */
+    elements[3*3 + k] = 0;
+  }
+
+  emin = comm_rank*3+start;
+  emax = emin+2;
+  printf("%d:%d %d\n",comm_rank,(int)emin,(int)emax);
+  if (cgp_parent_data_write(fn,B,Z,S,emin,emax,elements))
+    cgp_error_exit();
+
+  /* Side Connectivity */
+  for(k=0; k < 3; k++) {
+    elements[2*k+0] = 2*(comm_rank*3+k)+1;
+    elements[2*k+1] = 2*(comm_rank*3+k)+3;
+  }
+  if (cgp_elements_write_data(fn,B,Z,S,emin,emax,elements))
+    cgp_error_exit();
+
+  /* Left BC */
+  start = end + 1;
+  end   = start;
+  if (cgp_section_write(fn,B,Z,"Left",CGNS_ENUMV(BAR_2),start,end,0,&S))
+    cgp_error_exit();
+
+  if (comm_rank == 0) {
+    emin = start;
+    emax = end;
+
+    /* Parent Element/Side data */
+    elements[0] = 1; /* Element */
+    elements[1] = 0;
+    elements[2] = 4; /* Side */
+    elements[3] = 0;
+    el_ptr = elements;
+  }
+  else {
+    emin = 0;
+    emax = 0;
+    el_ptr = NULL;
+  }
+  printf("%d:%d %d\n",comm_rank,(int)emin,(int)emax);
+  if (cgp_parent_data_write(fn,B,Z,S,emin,emax,el_ptr))
+    cgp_error_exit();
+
+  /* Side Connectivity */
+  if (comm_rank == 0) {
+    elements[0] = 1;
+    elements[1] = 2;
+  }
+  if (cgp_elements_write_data(fn,B,Z,S,emin,emax,el_ptr))
+    cgp_error_exit();
+
+  if (cgp_close(fn)) cgp_error_exit();
+
+  err = MPI_Finalize();
+  if(err!=MPI_SUCCESS) cgp_doError;
+  return 0;
+}


### PR DESCRIPTION
A first shot at an implementation for cgp_parent_data_write. It works in the testing I have done on my local project, but not sure if the "style" is correct. It currently uses an MPI_Allreduce call to determine the total size of the ParentElements and ParentElementsPosition nodes which are created during the function. It might be cleaner to have two functions -- one to create the nodes and one to write the data to the nodes, but this implementation follows the behavior of the serial version.

There is a test that writes a 2D unstructured mesh and puts a BC on bottom and left side.

Let me know what you think and I will modify as needed.