### PR TITLE
Add cmake support for memory debugging; fix memory debug routines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ endif ("${CMAKE_SIZEOF_VOID_P}" GREATER 4)
 option(CGNS_ENABLE_LEGACY "Enable or disable building legacy code (3.0 compatible)" "OFF")
 option(CGNS_ENABLE_SCOPING "Enable or disable scoping of enumeration values" "OFF")
 option(CGNS_ENABLE_BASE_SCOPE "Enable or disable base scoped families or connectivities" "OFF")
+option(CGNS_ENABLE_MEM_DEBUG "Enable or disable memory debugging" "OFF")
 
 if (CGNS_ENABLE_LEGACY)
   set(CGNS_ENABLE_64BIT "OFF")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -452,6 +452,11 @@ set(cgns_C_FILES
 	adf/ADF_interface.c
 	adf/ADF_internals.c)
 
+if (CGNS_ENABLE_MEM_DEBUG)
+  set(cgns_C_FILES ${cgns_C_FILES} cg_malloc.c)
+  add_definitions("-DMEM_DEBUG")
+endif(CGNS_ENABLE_MEM_DEBUG)
+
 if (CGNS_ENABLE_HDF5)
   set(cgns_C_FILES ${cgns_C_FILES} adfh/ADFH.c)
   if (CGNS_ENABLE_PARALLEL)

--- a/src/cg_malloc.c
+++ b/src/cg_malloc.c
@@ -11,7 +11,8 @@ void *cgmalloc(size_t bytes) {
     size_t *data = (size_t *) malloc (bytes + 2 * sizeof(size_t));
     if (data) {
         *data++ = bytes;
-        *data++ = (size_t)(data + 1);
+        *data = (size_t)(data + 1);
+        data++;
         mem_now += bytes;
         if (mem_max < mem_now) mem_max = mem_now;
     }
@@ -28,7 +29,8 @@ void *cgrealloc(void *olddata, size_t bytes) {
     data = (size_t *) realloc (data, bytes + 2 * sizeof(size_t));
     if (data) {
         *data++ = bytes;
-        *data++ = (size_t)(data + 1);
+        *data = (size_t)(data + 1);
+        data++;
         mem_now += bytes;
         if (mem_max < mem_now) mem_max = mem_now;
     }
@@ -41,7 +43,8 @@ void *cgcalloc(size_t num, size_t bytes) {
     size_t *data = (size_t *) malloc (count + 2 * sizeof(size_t));
     if (data) {
         *data++ = count;
-        *data++ = (size_t)(data + 1);
+        *data = (size_t)(data + 1);
+        data++;
         mem_now += count;
         if (mem_max < mem_now) mem_max = mem_now;
         memset(data, 0, count);

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -342,8 +342,8 @@ int cg_open(const char *filename, int mode, int *file_number)
     float FileVersion;
 
 #ifdef __CG_MALLOC_H__
-    fprintf(stderr, "before open:files %d/%d: memory %d/%d\n", n_open,
-        cgns_file_size, cgmemnow(), cgmemmax());
+    fprintf(stderr, "CGNS MEM_DEBUG: before open:files %d/%d: memory %d/%d: calls %d/%d\n", n_open,
+	    cgns_file_size, cgmemnow(), cgmemmax(), cgalloccalls(), cgfreecalls());
 #endif
 
     /* check file mode */
@@ -503,8 +503,8 @@ int cg_open(const char *filename, int mode, int *file_number)
     }
 
 #ifdef __CG_MALLOC_H__
-    fprintf(stderr, "after  open:files %d/%d: memory %d/%d\n", n_open,
-        cgns_file_size, cgmemnow(), cgmemmax());
+    fprintf(stderr, "CGNS MEM_DEBUG: after  open:files %d/%d: memory %d/%d: calls %d/%d\n", n_open,
+	    cgns_file_size, cgmemnow(), cgmemmax(), cgalloccalls(), cgfreecalls());
 #endif
 
     return CG_OK;
@@ -621,8 +621,8 @@ int cg_close(int file_number)
     if (cg == 0) return CG_ERROR;
 
 #ifdef __CG_MALLOC_H__
-    fprintf(stderr, "before close:files %d/%d: memory %d/%d\n", n_open,
-        cgns_file_size, cgmemnow(), cgmemmax());
+    fprintf(stderr, "CGNS MEM_DEBUG: before close:files %d/%d: memory %d/%d: calls %d/%d\n", n_open,
+	    cgns_file_size, cgmemnow(), cgmemmax(), cgalloccalls(), cgfreecalls());
 #endif
 
     if (cgns_compress && cg->mode == CG_MODE_MODIFY &&
@@ -656,8 +656,8 @@ int cg_close(int file_number)
     }
 
 #ifdef __CG_MALLOC_H__
-    fprintf(stderr, "after  close:files %d/%d: memory %d/%d\n",
-        n_open, cgns_file_size, cgmemnow(), cgmemmax());
+    fprintf(stderr, "CGNS MEM_DEBUG: after  close:files %d/%d: memory %d/%d: calls %d/%d\n", n_open,
+	    cgns_file_size, cgmemnow(), cgmemmax(), cgalloccalls(), cgfreecalls());
 #endif
 
 #ifdef DEBUG_HDF5_OBJECTS_CLOSE


### PR DESCRIPTION
This PR permits the control of the memory debugging capability via cmake.  To enable, define CGNS_ENABLE_MEM_DEBUG=ON.

The address storing in cg_malloc did not seem to work correctly; perhaps an issue with sequence points, so separated the `*data++ = (size_t)(data + 1);` into two lines: `*data = (size_t)(data + 1);` and `data++;`

Slight modification to the memory debug output:
* Added "CGNS MEM_DEBUG" prefix to the output lines in cg_open and cg_close.
* Added output of the number of alloc and free calls.