### PR TITLE
Fix Windows build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -562,12 +562,9 @@ install(TARGETS cgns_static ARCHIVE DESTINATION lib)
 # Set the install path of the shared library
 if(CGNS_BUILD_SHARED)
   # for windows, need to install both cgnsdll.dll and cgnsdll.lib
-  if (WIN32 OR CYGWIN)
-    install(TARGETS cgns_shared ARCHIVE DESTINATION lib)
-    install(TARGETS cgns_shared RUNTIME DESTINATION lib)
-  else (WIN32 OR CYGWIN)
-    install(TARGETS cgns_shared LIBRARY DESTINATION lib)
-  endif (WIN32 OR CYGWIN)
+  install (TARGETS cgns_shared LIBRARY DESTINATION lib
+                               ARCHIVE DESTINATION lib
+                               RUNTIME DESTINATION bin)
 endif(CGNS_BUILD_SHARED)
 
 # Set the install path of the header files

--- a/src/adf/ADF.h
+++ b/src/adf/ADF.h
@@ -46,7 +46,7 @@ File:	ADF.h
 #include "cgnstypes.h"
 
 #if defined(_WIN32) && defined(BUILD_DLL)
-# define EXTERN extern _declspec(dllexport)
+# define EXTERN extern __declspec(dllexport)
 #else
 # define EXTERN extern
 #endif

--- a/src/adf/adf_ftoc.c
+++ b/src/adf/adf_ftoc.c
@@ -24,7 +24,7 @@ freely, subject to the following restrictions:
 #include "ADF_internals.h"
 
 #if defined(_WIN32) && defined(BUILD_DLL)
-# define CGNSDLL _declspec(dllexport)
+# define CGNSDLL __declspec(dllexport)
 #else
 # define CGNSDLL
 #endif

--- a/src/adfh/ADFH.h
+++ b/src/adfh/ADFH.h
@@ -175,7 +175,7 @@
 ***********************************************************************/
 
 #if defined(_WIN32) && defined(BUILD_DLL)
-# define EXTERN extern _declspec(dllexport)
+# define EXTERN extern __declspec(dllexport)
 #else
 # define EXTERN extern
 #endif

--- a/src/adfh/ADFH_ftoc.c
+++ b/src/adfh/ADFH_ftoc.c
@@ -24,7 +24,7 @@ freely, subject to the following restrictions:
 #include "ADFH.h"
 
 #if defined(_WIN32) && defined(BUILD_DLL)
-# define CGNSDLL _declspec(dllexport)
+# define CGNSDLL __declspec(dllexport)
 #else
 # define CGNSDLL
 #endif

--- a/src/cgio_ftoc.c
+++ b/src/cgio_ftoc.c
@@ -29,7 +29,7 @@ freely, subject to the following restrictions:
 #endif
 
 #if defined(_WIN32) && defined(BUILD_DLL)
-# define CGIODLL _declspec(dllexport)
+# define CGIODLL __declspec(dllexport)
 #else
 # define CGIODLL
 #endif

--- a/src/cgns_header.h
+++ b/src/cgns_header.h
@@ -944,7 +944,7 @@ typedef struct {
 /* need some of these routines exported for CGNStools */
 
 #if defined(_WIN32) && defined(BUILD_DLL)
-# define CGNSDLL _declspec(dllexport)
+# define CGNSDLL __declspec(dllexport)
 #else
 # define CGNSDLL
 #endif

--- a/src/cgns_io.h
+++ b/src/cgns_io.h
@@ -32,7 +32,7 @@
 #include "cgnstypes.h"
 
 #if defined(_WIN32) && defined(BUILD_DLL)
-# define CGEXTERN extern _declspec(dllexport)
+# define CGEXTERN extern __declspec(dllexport)
 #else
 # define CGEXTERN extern
 #endif

--- a/src/cgnslib.h
+++ b/src/cgnslib.h
@@ -56,9 +56,9 @@
 #ifndef CGNSDLL
 # ifdef _WIN32
 #  if defined(BUILD_DLL)
-#    define CGNSDLL _declspec(dllexport)
+#    define CGNSDLL __declspec(dllexport)
 #  elif defined(USE_DLL)
-#    define CGNSDLL _declspec(dllimport)
+#    define CGNSDLL __declspec(dllimport)
 #  else
 #    define CGNSDLL
 #  endif

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -69,12 +69,6 @@ if (WIN32)
   install(PROGRAMS
         cgnsupdate.bat
 	DESTINATION bin)
-  # lets also put the dll in here so they run
-  if (CGNS_USE_SHARED)
-    install(PROGRAMS
-        ${CMAKE_BINARY_DIR}/src/cgnsdll.dll
-	DESTINATION bin)
-  endif (CGNS_USE_SHARED)
   if (CGNS_ENABLE_HDF5)
     install(PROGRAMS
         adf2hdf.bat


### PR DESCRIPTION
Fixes mingw build:
- declspec keyword typo, xref https://msdn.microsoft.com/fr-fr/library/3y1sfaz2(v=vs.100).aspx
- install dll in bin in a simpler manner ; as the dll prefix is different on mingw we should avoid hardwire the dll name