### PR TITLE
If processor has no data, set end = start = 0

### DIFF
--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -540,6 +540,8 @@ int cgp_parent_data_write(int fn, int B, int Z, int S,
 	cgi_error("Error in requested element data range.");
 	return CG_ERROR;
       }    
+    } else {
+        start = end = 0;
     }
 
     if (!IS_FIXED_SIZE(section->el_type)) {


### PR DESCRIPTION
If a processor has no data to write, then the start and end values passed in are sometimes arbitrary from calling code.  For example end > start or end == start.  Depending on the values, there can be logic errors in the following code.  To avoid this, set start = end = 0 if a processor has no data to output (section->parelem == NULL).