### PR TITLE
Workaround OSX compiler bug

### DIFF
--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -600,8 +600,9 @@ int cgp_parent_data_write(int fn, int B, int Z, int S,
     if (cgi_write_array(section->id, section->parface)) return CG_ERROR;
 
     /* ParentElements -- write data */
+    cgsize_t delta = end - start;
     rmin[0] = start - section->range[0] + 1;
-    rmax[0] = end - section->range[0] + 1;
+    rmax[0] = rmin[0] + delta;
     rmin[1] = 1;
     rmax[1] = 2;
     type = cgi_datatype(section->parelem->data_type);


### PR DESCRIPTION
The changed code above is functionally equivalent to the original code, but I get HDF5 errors in H5Dwrite with the original code, but not with the changed code on OSX.  This is with clang-3.9.1 specifically, but I also saw with other compilers.  Not sure what the issue is.  I can also get correct behavior by adding a "printf(stderr, "%d %d\n", start, end)" after line 608.  Obviously something strange is happening and I am OK if the PR is rejected since it really adds no true value...  

Just proposing in case others are seeing a similar problem and this can provide a solution.