### PR TITLE
Drop obsolete matherr hack

### DIFF
--- a/src/cgnstools/cgnscalc/calcwish.c
+++ b/src/cgnstools/cgnscalc/calcwish.c
@@ -15,14 +15,6 @@
 #include "tk.h"
 #include "locale.h"
 
-/*
- * The following variable is a special hack that is needed in order for
- * Sun shared libraries to be used for Tcl.
- */
-
-extern int matherr();
-int *tclDummyMathPtr = (int *) matherr;
-
 #ifdef TK_TEST
 extern int		Tcltest_Init _ANSI_ARGS_((Tcl_Interp *interp));
 extern int		Tktest_Init _ANSI_ARGS_((Tcl_Interp *interp));

--- a/src/cgnstools/cgnsplot/plotwish.c
+++ b/src/cgnstools/cgnsplot/plotwish.c
@@ -15,14 +15,6 @@
 #include "tk.h"
 #include "locale.h"
 
-/*
- * The following variable is a special hack that is needed in order for
- * Sun shared libraries to be used for Tcl.
- */
-
-extern int matherr();
-int *tclDummyMathPtr = (int *) matherr;
-
 extern int Cgnstcl_Init _ANSI_ARGS_((Tcl_Interp *interp));
 extern int Tkogl_Init _ANSI_ARGS_((Tcl_Interp *interp));
 

--- a/src/cgnstools/cgnsview/cgiowish.c
+++ b/src/cgnstools/cgnsview/cgiowish.c
@@ -15,14 +15,6 @@
 #include "tk.h"
 #include "locale.h"
 
-/*
- * The following variable is a special hack that is needed in order for
- * Sun shared libraries to be used for Tcl.
- */
-
-extern int matherr();
-int *tclDummyMathPtr = (int *) matherr;
-
 #ifdef TK_TEST
 extern int		Tcltest_Init _ANSI_ARGS_((Tcl_Interp *interp));
 extern int		Tktest_Init _ANSI_ARGS_((Tcl_Interp *interp));

--- a/src/cgnstools/tkogl/tkAppInit.c
+++ b/src/cgnstools/tkogl/tkAppInit.c
@@ -2,16 +2,6 @@
 #include <GL/gl.h>
 #include "tkogl.h"
 
-/*
- * The following variable is a special hack that is needed in order for
- * Sun shared libraries to be used for Tcl.
- */
-
-#ifdef NEED_MATHERR
-extern int matherr();
-int *tclDummyMathPtr = (int *) matherr;
-#endif
-
 int Tcl_AppInit(Tcl_Interp *interp) 	/* Interpreter for application. */
 {
    if (Tcl_Init(interp) == TCL_ERROR)  return TCL_ERROR;


### PR DESCRIPTION
See https://wiki.tcl.tk/3577

Also, matherr has been removed from glibc since 2.27, see http://man7.org/linux/man-pages/man3/matherr.3.html.