### PR TITLE
Improve error messages, fix error check

### DIFF
--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -5826,12 +5826,16 @@ int cg_1to1_write(int file_number, int B, int Z, const char * connectname,
      /* verify input */
     index_dim = zone->index_dim;
     for (i=0; i<index_dim; i++) {   /* can't check donorrange because it may not yet be written */
-        if (range[i]<=0 || range[i+index_dim]>zone->nijk[i]) {
-            cgi_error("Invalid input range:  %d->%d",range[i], range[i+index_dim]);
+        if (range[i]<=0 ) {
+	    cgi_error("Invalid input range for %s at index %d, range is non-positive: %d", connectname, i, range[i]);
             return CG_ERROR;
         }
-        if (abs(transform[i])<0 || abs(transform[i])>index_dim) {
-            cgi_error("Invalid transformation index: %d.  The indices must all be between 1 and %d",i, index_dim);
+        else if (range[i+index_dim]>zone->nijk[i]) {
+	    cgi_error("Invalid input range for %s at index %d, range exceeds zone bounds: %d -> %d", connectname, i, range[i+index_dim], zone->nijk[i]);
+            return CG_ERROR;
+        }
+        if (abs(transform[i])<1 || abs(transform[i])>index_dim) {
+            cgi_error("Invalid transformation for %s at index %d.  The indices must all be between 1 and %d", connectname, i, index_dim);
             return CG_ERROR;
         }
         if (abs(transform[i])>0) {
@@ -5840,8 +5844,8 @@ int cg_1to1_write(int file_number, int B, int Z, const char * connectname,
 	    dr = range[i+index_dim] - range[i];
 	    ddr = donor_range[j+index_dim] - donor_range[j];
 	    if (dr != ddr && dr != -ddr) {
-                cgi_error("Invalid input:  range = %d->%d and donor_range = %d->%d",
-                range[i], range[i+index_dim], donor_range[j], donor_range[j+index_dim]);
+                cgi_error("Invalid input for %s:  range = %d->%d and donor_range = %d->%d",
+                connectname, range[i], range[i+index_dim], donor_range[j], donor_range[j+index_dim]);
                 return CG_ERROR;
             }
         }


### PR DESCRIPTION
Improved the error messages.  The original message for checking for valid range would output something that didn't make sense or at least wasn't helpful.  Split this into two checks and output info that helps locate problem.

Added `connectname` to error messages to show which connection had issues.

The transform check was testing `abs(transform[i]) < 0` which isn't possible.  It should be `<=0` or `<1`