### PR TITLE
Revert "Improve error messages, fix error check"

### DIFF
--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -5826,16 +5826,12 @@ int cg_1to1_write(int file_number, int B, int Z, const char * connectname,
      /* verify input */
     index_dim = zone->index_dim;
     for (i=0; i<index_dim; i++) {   /* can't check donorrange because it may not yet be written */
-        if (range[i]<=0 ) {
-	    cgi_error("Invalid input range for %s at index %d, range is non-positive: %d", connectname, i, range[i]);
+        if (range[i]<=0 || range[i+index_dim]>zone->nijk[i]) {
+            cgi_error("Invalid input range:  %d->%d",range[i], range[i+index_dim]);
             return CG_ERROR;
         }
-        else if (range[i+index_dim]>zone->nijk[i]) {
-	    cgi_error("Invalid input range for %s at index %d, range exceeds zone bounds: %d -> %d", connectname, i, range[i+index_dim], zone->nijk[i]);
-            return CG_ERROR;
-        }
-        if (abs(transform[i])<1 || abs(transform[i])>index_dim) {
-            cgi_error("Invalid transformation for %s at index %d.  The indices must all be between 1 and %d", connectname, i, index_dim);
+        if (abs(transform[i])<0 || abs(transform[i])>index_dim) {
+            cgi_error("Invalid transformation index: %d.  The indices must all be between 1 and %d",i, index_dim);
             return CG_ERROR;
         }
         if (abs(transform[i])>0) {
@@ -5844,8 +5840,8 @@ int cg_1to1_write(int file_number, int B, int Z, const char * connectname,
 	    dr = range[i+index_dim] - range[i];
 	    ddr = donor_range[j+index_dim] - donor_range[j];
 	    if (dr != ddr && dr != -ddr) {
-                cgi_error("Invalid input for %s:  range = %d->%d and donor_range = %d->%d",
-                connectname, range[i], range[i+index_dim], donor_range[j], donor_range[j+index_dim]);
+                cgi_error("Invalid input:  range = %d->%d and donor_range = %d->%d",
+                range[i], range[i+index_dim], donor_range[j], donor_range[j+index_dim]);
                 return CG_ERROR;
             }
         }


### PR DESCRIPTION
Reverts CGNS/CGNS#62

Via Mark,

Fortunately, I just spent most of April refactoring some 1-to-1 connection logic in our code (ala CGNS), and so, I was able to see that #62 breaks/violates the CGNS SIDS.

 

The “transform” for 1:1 connections is allowed to be 0 in null (singleton) dimensions.  Section 8.1 of the SIDS:

 

http://cgns.github.io/CGNS_docs_current/sids/cnct.html#GridConnectivity1to1

 

Says the following:

 

For establishing relationships between adjacent and current zone indices lying on the interface itself, one of the elements of Transform is superfluous since one component of both interface indices remains constant. It is therefore acceptable to set that element of Transform to zero.

 

The new check in #63 on line 5837 is not allowing abs(transform)==0, thereby violating the above statement (in red).

 

If you look at the logic immediately after that check, there is an “if abs(transform)>0” on line 5841 – that check is needed to allow for 0 in some transform components, and would otherwise not be needed if the transform was not allowed to have a 0.

 