### PR TITLE
Test AppVeyor matrix correctly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,7 +100,7 @@ before_build:
   - cmake --version
   - SET HDF5_DIR=/Program Files/HDF_Group/HDF5/%HDF_VER%/cmake
   - cmake -G "Visual Studio 14 Win64" ^
-     %build_opts% ^
+     %build_opt% ^
      -D CMAKE_C_FLAGS:STRING="" ^
      -D CMAKE_BUILD_TYPE:STRING=Release ^
      -D HDF5_NEED_ZLIB:BOOL=ON ^


### PR DESCRIPTION
Reported at https://cgnsorg.atlassian.net/projects/CGNS/issues/CGNS-145
See also: https://github.com/CGNS/CGNS/commit/59d88143513fcd6fd7eac56d5a39df5cc022b618#r30513524

TL;DR: AppVeyor build matrix was not being exercised, wrong variable was being dereferenced