### PR TITLE
Fix broken test with Rind Plane Indexing

### DIFF
--- a/src/cg_ftoc.c
+++ b/src/cg_ftoc.c
@@ -243,14 +243,14 @@ CGNSDLL void FMNAME(cg_add_path_f, CG_ADD_PATH_F) (STR_PSTR(pathname),
 
 CGNSDLL void cg_set_rind_zero_f(cgint_f *ier)
 {
-    *ier = (cgint_f)cg_configure(CG_CONFIG_RIND_INDEX, CG_CONFIG_RIND_ZERO);
+    *ier = (cgint_f)cg_configure(CG_CONFIG_RIND_INDEX, (void *)CG_CONFIG_RIND_ZERO);
 }
 
 /*-----------------------------------------------------------------------*/
 
 CGNSDLL void cg_set_rind_core_f(cgint_f *ier)
 {
-    *ier = (cgint_f)cg_configure(CG_CONFIG_RIND_INDEX, CG_CONFIG_RIND_CORE);
+    *ier = (cgint_f)cg_configure(CG_CONFIG_RIND_INDEX, (void *)CG_CONFIG_RIND_CORE);
 }
 
 /*-----------------------------------------------------------------------*/
@@ -779,7 +779,7 @@ CGNSDLL void FMNAME(cg_coord_read_f, CG_COORD_READ_F) (cgint_f *fn, cgint_f *B,
 /*-----------------------------------------------------------------------*/
 
 CGNSDLL void FMNAME(cg_coord_general_read_f, CG_COORD_GENERAL_READ_F) (cgint_f *fn,
-        cgint_f *B, cgint_f *Z, cgint_f *G, STR_PSTR(coordname),
+        cgint_f *B, cgint_f *Z, STR_PSTR(coordname),
         CGNS_ENUMT(DataType_t) *type, cgsize_t *rmin, cgsize_t *rmax,
         cgint_f *m_numdim, cgsize_t *m_dim,
         cgsize_t *m_rmin, cgsize_t *m_rmax,
@@ -793,7 +793,7 @@ CGNSDLL void FMNAME(cg_coord_general_read_f, CG_COORD_GENERAL_READ_F) (cgint_f *
 #if DEBUG_FTOC
     printf("coordname='%s'\n", c_name);
 #endif
-    *ier = (cgint_f)cg_coord_general_read((int)*fn, (int)*B, (int)*Z, (int)*G,
+    *ier = (cgint_f)cg_coord_general_read((int)*fn, (int)*B, (int)*Z,
                c_name, *type, rmin, rmax, (int)*m_numdim, m_dim,
 	       m_rmin, m_rmax, coord);
 }
@@ -851,7 +851,7 @@ CGNSDLL void FMNAME(cg_coord_partial_write_f, CG_COORD_PARTIAL_WRITE_F) (
 /*-----------------------------------------------------------------------*/
 
 CGNSDLL void FMNAME(cg_coord_general_write_f, CG_COORD_GENERAL_WRITE_F) (
-        cgint_f *fn, cgint_f *B, cgint_f *Z, cgint_f *G, CGNS_ENUMT(DataType_t) *type,
+        cgint_f *fn, cgint_f *B, cgint_f *Z, CGNS_ENUMT(DataType_t) *type,
         STR_PSTR(coordname), cgsize_t *rmin, cgsize_t *rmax, cgint_f *m_numdim,
         cgsize_t *m_dims, cgsize_t *m_rmin, cgsize_t *m_rmax, void *coord, cgint_f *C,
         cgint_f *ier STR_PLEN(coordname))
@@ -866,7 +866,7 @@ CGNSDLL void FMNAME(cg_coord_general_write_f, CG_COORD_GENERAL_WRITE_F) (
     printf("    coordname='%s'\n", c_name);
 #endif
     *ier = (cgint_f)cg_coord_general_write((int)*fn, (int)*B, (int)*Z,
-               (int)*G, (CGNS_ENUMT(DataType_t))*type, c_name,
+               (CGNS_ENUMT(DataType_t))*type, c_name,
 	       rmin, rmax, (int)*m_numdim, m_dims, m_rmin, m_rmax,
                coord, &i_C);
     *C = (cgint_f)i_C;

--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -7039,7 +7039,7 @@ int cgi_write_model(double parent_id, cgns_model *model)
     }
 
      /* xModel_t */
-    sprintf(label,"%s_t",model->name);
+    sprintf(label,"%.30s_t",model->name);
     dim_vals = (cgsize_t)strlen(ModelTypeName[model->type]);
 
     if (cgi_new_node(parent_id, model->name, label, &model->id,

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -5498,7 +5498,6 @@ int cg_field_partial_write(int file_number, int B, int Z, int S,
 {
     cgns_zone *zone;
     cgns_sol *sol;
-    cgns_array *field;
     int n, m_numdim;
     cgsize_t m_dims[CGIO_MAX_DIMENSIONS];
     cgsize_t m_rmin[CGIO_MAX_DIMENSIONS], m_rmax[CGIO_MAX_DIMENSIONS];

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -3967,7 +3967,6 @@ int cg_elements_partial_write(int file_number, int B, int Z, int S,
         oldelems = (cgsize_t *)section->connect->data;
         oldsize = section->connect->dim_vals[0];
         newsize = ElementDataSize;
-        printf("newsize : %d\n", newsize);
 
         if (end < section->range[0]) {
             newsize += oldsize;

--- a/src/tests/test_general_rind.c
+++ b/src/tests/test_general_rind.c
@@ -122,13 +122,13 @@ int main (int argc, char *argv[])
         cg_goto(cgfile, cgbase, "Zone_t", cgzone,
             "GridCoordinates_t", cggrid, "end") ||
         cg_rind_write(rind) ||
-	cg_coord_general_write(cgfile, cgbase, cgzone, cggrid,
+	cg_coord_general_write(cgfile, cgbase, cgzone,
 	       	CGNS_ENUMV( RealSingle ), "CoordinateX",
 		rmin, rmax, 3, dims, m_rmin, m_rmax, xcoord, &cgcoor) ||
-	cg_coord_general_write(cgfile, cgbase, cgzone, cggrid,
+	cg_coord_general_write(cgfile, cgbase, cgzone,
 	       	CGNS_ENUMV( RealSingle ), "CoordinateY",
 		rmin, rmax, 3, dims, m_rmin, m_rmax, ycoord, &cgcoor) ||
-	cg_coord_general_write(cgfile, cgbase, cgzone, cggrid,
+	cg_coord_general_write(cgfile, cgbase, cgzone,
 		CGNS_ENUMV( RealSingle ), "CoordinateZ",
 		rmin, rmax, 3, dims, m_rmin, m_rmax, zcoord, &cgcoor))
         cg_error_exit();
@@ -169,7 +169,7 @@ int main (int argc, char *argv[])
         m_rmax[n] = rind[2*n] + size[n];
     }
 
-    if (cg_coord_general_read(cgfile, cgbase, cgzone, cggrid, "CoordinateX",
+    if (cg_coord_general_read(cgfile, cgbase, cgzone, "CoordinateX",
             CGNS_ENUMV(RealSingle), rmin, rmax, 3, dims, m_rmin, m_rmax, fbuf))
         cg_error_exit();
 
@@ -185,7 +185,7 @@ int main (int argc, char *argv[])
     nn += np;
     if (np) printf("%d differences in CoordinateX\n", np);
 
-    if (cg_coord_general_read(cgfile, cgbase, cgzone, cggrid, "CoordinateY",
+    if (cg_coord_general_read(cgfile, cgbase, cgzone, "CoordinateY",
             CGNS_ENUMV(RealSingle), rmin, rmax, 3, dims, m_rmin, m_rmax, fbuf))
         cg_error_exit();
 
@@ -201,7 +201,7 @@ int main (int argc, char *argv[])
     nn += np;
     if (np) printf("%d differences in CoordinateY\n", np);
 
-    if (cg_coord_general_read(cgfile, cgbase, cgzone, cggrid, "CoordinateZ",
+    if (cg_coord_general_read(cgfile, cgbase, cgzone, "CoordinateZ",
             CGNS_ENUMV(RealSingle), rmin, rmax, 3, dims, m_rmin, m_rmax, fbuf))
         cg_error_exit();
                                                                                   

--- a/src/tests/test_general_rindf.F
+++ b/src/tests/test_general_rindf.F
@@ -90,17 +90,17 @@ c write zone
      &               'GridCoordinates_t', cggrid, 'end')
       call cg_rind_write_f(rind, ierr)
 c write coordinates
-      call cg_coord_general_write_f(cgfile, cgbase, cgzone, cggrid,
+      call cg_coord_general_write_f(cgfile, cgbase, cgzone,
      &                      Realsingle, coordname(1),
      &                      rmin, rmax, 3, dims, mrmin, mrmax,
      &                      x, cgcoord, ierr)
       if (ierr .ne. CG_OK) call cg_error_exit_f
-      call cg_coord_general_write_f(cgfile, cgbase, cgzone, cggrid,
+      call cg_coord_general_write_f(cgfile, cgbase, cgzone,
      &                      RealSingle, coordname(2),
      &                      rmin, rmax, 3, dims, mrmin, mrmax,
      &                      y, cgcoord, ierr)
       if (ierr .ne. CG_OK) call cg_error_exit_f
-      call cg_coord_general_write_f(cgfile, cgbase, cgzone, cggrid,
+      call cg_coord_general_write_f(cgfile, cgbase, cgzone,
      &                      RealSingle, coordname(3),
      &                      rmin, rmax, 3, dims, mrmin, mrmax,
      &                      z, cgcoord, ierr)
@@ -142,7 +142,7 @@ c only load core coordinates without rind but inside memory with rind
         mrmax(n) = rind(2*n-1) + size(n)
       enddo
 
-      call cg_coord_general_read_f(cgfile, cgbase, cgzone, cggrid,
+      call cg_coord_general_read_f(cgfile, cgbase, cgzone,
      &     'CoordinateX', RealSingle, rmin, rmax, 3,
      &     dims, mrmin, mrmax, fbuf, ierr)
       if (ierr .eq. ERROR) call cg_error_exit_f
@@ -161,7 +161,7 @@ c only load core coordinates without rind but inside memory with rind
         print *,'differences in CoordinateX'
       endif
 
-      call cg_coord_general_read_f(cgfile, cgbase, cgzone, cggrid,
+      call cg_coord_general_read_f(cgfile, cgbase, cgzone,
      &     'CoordinateY', RealSingle, rmin, rmax, 3,
      &     dims, mrmin, mrmax, fbuf, ierr)
       if (ierr .eq. ERROR) call cg_error_exit_f
@@ -180,7 +180,7 @@ c only load core coordinates without rind but inside memory with rind
         print *,'differences in CoordinateY'
       endif
 
-      call cg_coord_general_read_f(cgfile, cgbase, cgzone, cggrid,
+      call cg_coord_general_read_f(cgfile, cgbase, cgzone,
      &     'CoordinateZ', RealSingle, rmin, rmax, 3,
      &     dims, mrmin, mrmax, fbuf, ierr)
       if (ierr .eq. ERROR) call cg_error_exit_f


### PR DESCRIPTION
Following the removal of grid number as a  parameter for cg_coord_general_xxx, tests were failing.

As a side note, deforming meshes using multiple GridCoordinates nodes won't be readable or writable with rind planes with the new API since cg_array_general_read/write is not aware of Rind Indexing thus always falling back to a CG_CONFIG_RIND_ZERO state (as it was done before).