### PR TITLE
CGNS-146 (#87)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -608,7 +608,7 @@ set(headers
 
 if (CGNS_ENABLE_FORTRAN)
   list(APPEND headers
-    ${CMAKE_CURRENT_BINARY_DIR}/cgns.mod)
+    $<TARGET_FILE_DIR:cgns_static>/cgns.mod)
 endif (CGNS_ENABLE_FORTRAN)
 
 if (CGNS_ENABLE_PARALLEL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -612,8 +612,13 @@ set(headers
   ${CMAKE_CURRENT_BINARY_DIR}/cgnsBuild.defs)
 
 if (CGNS_ENABLE_FORTRAN)
-  list(APPEND headers
-    $<TARGET_FILE_DIR:cgns_static>/cgns.mod)
+  if(DEFINED CMAKE_Fortran_MODULE_DIRECTORY)
+    list(APPEND headers
+      ${CMAKE_Fortran_MODULE_DIRECTORY}/cgns.mod)
+  else()
+    list(APPEND headers
+      $<TARGET_FILE_DIR:cgns_static>/cgns.mod)
+  endif()
 endif (CGNS_ENABLE_FORTRAN)
 
 if (CGNS_ENABLE_PARALLEL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -532,6 +532,8 @@ if (CGNS_ENABLE_FORTRAN)
 else (CGNS_ENABLE_FORTRAN)
   add_library(cgns_static STATIC ${cgns_FILES})
 endif (CGNS_ENABLE_FORTRAN)
+# Needed to work around a CMake > 3.8 bug on Windows with MSVS and Intel Fortran
+set_property(TARGET cgns_static PROPERTY LINKER_LANGUAGE C)
 
 
 # Build a shared version of the library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,6 +236,11 @@ CHECK_FORTRAN_FEATURE(Fortran2008
            END FUNCTION bind2
          END INTERFACE
        END MODULE test
+
+       PROGRAM main
+         USE test
+         IMPLICIT NONE
+       END PROGRAM
   "
   CHECK_FORTRAN_2008
 )


### PR DESCRIPTION
* CGNS-146 :: Can't compile using MSVC & IVF on windows (MSVS 14)

Explicitly set the CMake `LINKER_LANGUAGE` property on `cngs_static` to `C`.
This is a work around for a potential CMake bug, and was suggested by
@bradking. Here is the issue and merge that introduced the bug:

 - https://gitlab.kitware.com/cmake/cmake/issues/16738
 - https://gitlab.kitware.com/cmake/cmake/merge_requests/643