### PR TITLE
RPATH handling for MacOSX (Darwin)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,10 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 # which point to directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+IF (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+   set(CMAKE_MACOSX_RPATH TRUE)
+ENDIF()
+
 #-----------------------------------------------------------------------------
 # Dashboard and Testing Settings
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,7 +362,7 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 # which point to directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-IF (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
    set(CMAKE_MACOSX_RPATH TRUE)
 ENDIF()
 


### PR DESCRIPTION
On Mac OSX, (Darwin), I think that this is needed for proper RPATH handling.  I have been manually setting this in my builds on Mac, but I think it should be handled automatically in the CGNS CMakeLists.txt...