### PR TITLE
Support for std C on linux

### DIFF
--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -18,6 +18,9 @@ freely, subject to the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 -------------------------------------------------------------------------*/
 
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 500
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/tests/ser_benchmark_hdf5.c
+++ b/src/tests/ser_benchmark_hdf5.c
@@ -12,6 +12,9 @@
 ! The value of nnY is the number of nodes along the Y direction. 
 !
 */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 500
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Allows library and tests to compile using some variant of iso C.  S_IFREG and M_PI are not accessible unless _XOPEN_SOURCE >= 500.  This does not modify an existing definition of _XOPEN_SOURCE.