### PR TITLE
Eliminate potential integer overflow / undefined behavior

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -2386,9 +2386,13 @@ void ADFH_Database_Close(const double  root,
 
   ADFH_DEBUG(("ADFH_Database_Close 1"));
   idx=0;
-  for (n = 0; n < ADFH_MAXIMUM_FILES; n++)  idx+=mta_root->g_files[n];
+  for (n = 0; n < ADFH_MAXIMUM_FILES; n++) {
+    if (mta_root->g_files[n]) {
+      idx++;
+    }
+  }
   /* if no more files open, close properties and free MTA */
-  if (!idx) {
+  if (idx == 0) {
     H5Pclose(mta_root->g_proplink);
     H5Pclose(mta_root->g_propgroupcreate);
     H5Pclose(mta_root->g_propdataset);


### PR DESCRIPTION
The check for open files was summing the `g_files` entry when all that was needed was a yes/no on whether there were any open files.  Depending of the value of `g_files` it was possible for the integer sum to overflow the range of a signed int which gives undefined behavior.  `idx` is an integer and `g_files` is an `hid_t` which is 64-bits on recent HDF5 versions, so overflow is definitely a possibility (and has happened in the wild)