### PR TITLE
Order include directives to get correct includes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ if (WIN32)
 endif (WIN32)
 
 # Include the local directory
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 if (CGNS_ENABLE_HDF5)
   add_definitions(-DBUILD_HDF5)
   if (WIN32)
@@ -484,7 +484,7 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/cgnsconfig.h.in
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/cgnsBuild.defs.in
 		${CMAKE_CURRENT_BINARY_DIR}/cgnsBuild.defs )
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 ###########
 # Library #


### PR DESCRIPTION
In the current CMake build, the `${CMAKE_CURRENT_BINARY_DIR}` include is the last one on the compilation line.  This directory contains the most up-to-date version of the `cgnstypes.h` include file.  If there is another version of `cgnstypes.h` existing in an install directory, perhaps the same directory containing hdf5 or some other include files, then the older `cgnstypes.h` will be included instead of the more current one.    Here is an example of the include specifications for the PATCHED and ORIGINAL compilation commands:
```
ORIGINAL:
cd /gpfs1/cgns/CGNS/build/src && mpicc 
-I/gpfs1/install_dir/include 
-I/gpfs1/cgns/CGNS/src 
-I/gpfs1/cgns/CGNS/build/src  
-I/gpfs1/install_dir/include 


PATCHED:
cd /gpfs1/cgns/CGNS/build/src && mpicc 
-I/gpfs1/cgns/CGNS/build/src 
-I/gpfs1/cgns/CGNS/src 
-I/gpfs1/install_dir/include  
-I/gpfs1/install_dir/include 
```