### PR TITLE
Create hdf5-1.8.x compatible files from 1.10.X library

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -2061,7 +2061,11 @@ void ADFH_Database_Open(const char   *name,
   /*  H5Pset_latest_format(fapl, 1); */
   /* Performance patch applied by KSH on 2009.05.18 */
   H5Pset_libver_bounds(g_propfileopen,
+#if H5_VERSION_GE(1,10,3)
+		       H5F_LIBVER_V18, H5F_LIBVER_V18);
+#else
 		       H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
+#endif
   /* open the file */
 
 #ifdef BUILD_PARALLEL


### PR DESCRIPTION
If CGNS is built against the new HDF5-1.10.x library versions, the files that are created are not readable by applications which are built against earlier HDF5-1.8.x library versions.  This can cause issues on many systems which are using commercial or externally maintained visualization or other applications (ParaView, Ensight, ...) . 

Adding the command to use the `H5F_LIBVER_V18` option makes the files readable by the older applications.  

Here is some advice from the HDF5 group related to this issue:
```
If an application written for 1.8.* is linked with HDF5 1.10.(i.e., it doesn’t use any new features of 1.10.0), a file created by the application will be readable by HDF5 1.8. (or even earlier versions). The exception to this rule would be an application that uses H5Pset_libver_bounds with H5F_LIBVER_LATEST value for its “low” and “high” parameters.

In this case both parameters should be set to H5F_LIBVER_V18 to create 1.8 compatible file.

File control versioning became available in the HDF5 1.10.3 release. As a safeguard feature, we recommend using H5Pset_libver_bounds function to control file versioning.
```