### PR TITLE
Fix for OSX Build

### DIFF
--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -19,7 +19,7 @@ freely, subject to the following restrictions:
 -------------------------------------------------------------------------*/
 
 #ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 #endif
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
On OSX, the XOPEN version needs to be at least 600 to include the function prototype for `readlink` using the following compiler:
```
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
Target: x86_64-apple-darwin17.7.0
```
The warning is:
```
/Users/gdsjaar/src/seacas/TPL/cgns/CGNS/src/cgns_io.c:229:15: warning: implicit declaration of function 'readlink' is invalid in C99
      [-Wimplicit-function-declaration]
        len = readlink(filename, linkfile, st.st_size + 1);
              ^
```
When `_XOPEN_SOURCE` is defined to be 500.  Warning goes away when defined to be 600.  

This also happens with gcc-8.3.0 on OSX.