### PR TITLE
Fix tests for scoped enum use

### DIFF
--- a/src/Test_UserGuideCode/C_code_parallel/write_grid_str_parinzone.c
+++ b/src/Test_UserGuideCode/C_code_parallel/write_grid_str_parinzone.c
@@ -46,7 +46,7 @@ int main(int argc, const char* argv[])
    sprintf(zonename, "Zone %d", 1);
 /* create zone */
    if (cg_zone_write(index_file, index_base, zonename, (cgsize_t*)zoneSize,
-                     Structured, &index_zone)) cg_error_exit();
+                     CGNS_ENUMV(Structured), &index_zone)) cg_error_exit();
    if (cg_grid_write(index_file, index_base, index_zone, "GridCoordinates",
                      &index_grid)) cg_error_exit();
 /* construct the grid coordinates nodes (user must use SIDS-standard names

--- a/src/Test_UserGuideCode/C_code_parallel/write_grid_str_paroverzone.c
+++ b/src/Test_UserGuideCode/C_code_parallel/write_grid_str_paroverzone.c
@@ -55,7 +55,7 @@ int main(int argc, const char* argv[])
        sprintf(zonename, "Zone %d", idxZone + 1);
 /* create zone */
        if (cg_zone_write(index_file, index_base,
-                         zonename, (cgsize_t*)zoneSize[idxZone], Structured,
+                         zonename, (cgsize_t*)zoneSize[idxZone], CGNS_ENUMV(Structured),
                          &index_zone)) cg_error_exit();
        if (cg_grid_write(index_file, index_base, index_zone,
                          "GridCoordinates", &index_grid)) cg_error_exit();

--- a/src/ptests/test_general_readwrite.c
+++ b/src/ptests/test_general_readwrite.c
@@ -210,7 +210,7 @@ int main (int argc, char *argv[])
     /* write solution with rind, and the solution dimensions come from the zone
      * sizes */
 
-    if (cg_sol_write(cgfile, cgbase, cgzone, "VertexSolution", Vertex,
+    if (cg_sol_write(cgfile, cgbase, cgzone, "VertexSolution", CGNS_ENUMV(Vertex),
                      &cgsol) ||
         cg_goto(cgfile, cgbase, "Zone_t", cgzone,
             "FlowSolution_t", cgsol, "end") ||


### PR DESCRIPTION
There are a few uses of CGNS Enums which were not wrapped by the `CGNS_ENUMV()` macro. Fixed so now tests will build with `CG_SCOPED_ENUMS` defined.