### PR TITLE
Fix global-buffer-overflow in ADFI_string_2_C_string.

### DIFF
--- a/src/adf/ADF_internals.c
+++ b/src/adf/ADF_internals.c
@@ -7406,8 +7406,16 @@ if( (string == NULL) || (c_string == NULL) ) {
 
 *error_return = NO_ERROR ;
 
+	/** Search for early NULL termination **/
+for( iend=0; iend < string_length; iend++ ) {
+   if( string[ iend ] == '\0' ) {
+      break ;
+      } /* end if */
+   } /* end for */
+   iend--;
+
 	/** Skip and trailing blanks **/
-for( iend=string_length-1; iend>=0; iend-- ) {
+for( ; iend>=0; iend-- ) {
    if( string[ iend ] != ' ' ) {
       break ;
       } /* end if */

--- a/src/adf/ADF_internals.c
+++ b/src/adf/ADF_internals.c
@@ -7412,7 +7412,7 @@ for( iend=0; iend < string_length; iend++ ) {
       break ;
       } /* end if */
    } /* end for */
-   iend--;
+iend--;
 
 	/** Skip and trailing blanks **/
 for( ; iend>=0; iend-- ) {


### PR DESCRIPTION
Add a search loop for an early NULL termination of the string passed to ADFI_string_2_C_string in order to prevent global-buffer-overflow when string literals are given as a parameter.
Fixes issue CGNS-159.