### PR TITLE
Fix heap buffer overflow in cgi_read_ptset

### DIFF
--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -3111,7 +3111,8 @@ int cgi_read_ptset(double parent_id, cgns_ptset *ptset)
      /* size_of_patch */
     if (ptset->type == CGNS_ENUMV(PointList) ||
         ptset->type == CGNS_ENUMV(ElementList) ||
-        ptset->type == CGNS_ENUMV(PointListDonor)) {
+        ptset->type == CGNS_ENUMV(PointListDonor) ||
+        ptset->type == CGNS_ENUMV(CellListDonor)) {
         ptset->size_of_patch = ptset->npts;
     }
     else {


### PR DESCRIPTION
In cgi_read_ptset there is made a difference between point set of list and range type.
The 'CellListDonor' type was missing in the list of list types and this led to a heap buffer overflow.

Added 'CellListDonor' type to list of list types.

Fixes issue CGNS-158