### PR TITLE
Fix cgnstools install

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -4711,8 +4711,8 @@ fi
 if test -z $exec_prefix || test $exec_prefix = NONE; then
   exec_prefix=$prefix
 fi
-if test "$datadir" = "\${prefix}/share"; then
-  datadir=$datadir/cgnstools
+if test "$datarootdir" = "\${prefix}/share"; then
+  datadir=$datarootdir/cgnstools
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking where to install library" >&5

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -237,8 +237,8 @@ fi
 if test -z $exec_prefix || test $exec_prefix = NONE; then
   exec_prefix=$prefix
 fi
-if test "$datadir" = "\${prefix}/share"; then
-  datadir=$datadir/cgnstools
+if test "$datarootdir" = "\${prefix}/share"; then
+  datadir=$datarootdir/cgnstools
 fi
 
 AC_MSG_CHECKING([where to install library])


### PR DESCRIPTION
If the CGNS is configured with `configure --prefix=somedir` then `make install` fails with the error

> ----- cgnsview -----
> Making directory /share
> mkdir: cannot create directory ‘/share’: Permission denied

This is because the path variable remains unexpanded in src/cgnstools/make.defs: `LIB_INSTALL_DIR = ${prefix}/share`

This PR fixes the issue.