### PR TITLE
Use correct MPI communicator

### DIFF
--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -897,7 +897,7 @@ int cgp_parent_data_write(int fn, int B, int Z, int S,
     cgsize_t num = end == 0 ? 0 : end - start + 1;
     num = num < 0 ? 0 : num;
     MPI_Datatype mpi_type = sizeof(cgsize_t) == 32 ? MPI_INT : MPI_LONG_LONG_INT;
-    MPI_Allreduce(MPI_IN_PLACE, &num, 1, mpi_type, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &num, 1, mpi_type, MPI_SUM, cgp_mpi_comm);
 
     strcpy(section->parelem->data_type, CG_SIZE_DATATYPE);
     section->parelem->data_dim = 2;


### PR DESCRIPTION
The `MPI_Allreduce` call in `cgp_parent_data_write()` is using `MPI_COMM_WORLD`  It would be more correct to use the communicator stored in `cgp_mpi_comm` which is set by the client. If the client is not using `MPI_COMM_WORLD` and calls this function, it will hang since not all ranks will be participating in the call.  

There is another use of `MPI_COMM_WORLD` in `cgp_error_exit()`, but I'm not sure if there is a use case for keeping that as is (I seem to remember some discussion a year or so ago)