### PR TITLE
Fix incorrect variable type

### DIFF
--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -7967,7 +7967,8 @@ int cgi_array_general_verify_range(
     cgsize_t *numpt)                    /* [O] number of points accessed */
 {
     cgsize_t s_numpt = 1, m_numpt = 1;
-    int n, npt;
+    cgsize_t npt;
+    int n;
 
     int s_reset_range = 1;
     *s_access_full_range = 1;


### PR DESCRIPTION
Minor fix; only applicable if more than 2.1 billion intervals in a range, but does eliminate a compiler warning -- `npt` should be `cgsize_t`