### PR TITLE
remove warning from -Wunused-result

### DIFF
--- a/src/adf/ADF_interface.c
+++ b/src/adf/ADF_interface.c
@@ -1019,7 +1019,11 @@ void	ADF_Database_Valid(
             *error_return = FILE_OPEN_ERROR;
         return;
     }
-    fread (header, sizeof(char), 32, fp);
+    if (32 != fread (header, sizeof(char), 32, fp)) {
+        *error_return = FREAD_ERROR;
+        fclose (fp);
+        return;
+    }
     fclose (fp);
     header[32] = 0;
     if (strncmp (&header[4], "ADF Database Version", 20))

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -603,7 +603,9 @@ int cgio_check_file (const char *filename, int *file_type)
 	}
 	return err;
       }
-    fread (buf, 1, sizeof(buf), fp);
+    if (sizeof(buf) != fread (buf, 1, sizeof(buf), fp)) {
+      buf[4] = 0;
+    }
     buf[sizeof(buf)-1] = 0;
     fclose (fp);
 


### PR DESCRIPTION
on travis two warnings keep appearing, this commit remove them