### PR TITLE
CMakeLists.txt: Disable RPATH setting if not using shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,23 +345,25 @@ endif (CGNS_ENABLE_HDF5 AND HDF5_NEED_MPI)
 # RPATH Management #
 ####################
 
-# use, i.e. don't skip the full RPATH for the build tree
-set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+if (CGNS_USE_SHARED)
+  # use, i.e. don't skip the full RPATH for the build tree
+  set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
-# when building, don't use the install RPATH already
-# (but later on when installing)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+  # when building, don't use the install RPATH already
+  # (but later on when installing)
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
-# the RPATH to be used when installing
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  # the RPATH to be used when installing
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
-# add the automatically determined parts of the RPATH
-# which point to directories outside the build tree to the install RPATH
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  # add the automatically determined parts of the RPATH
+  # which point to directories outside the build tree to the install RPATH
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-   set(CMAKE_MACOSX_RPATH TRUE)
-ENDIF()
+  IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+     set(CMAKE_MACOSX_RPATH TRUE)
+  ENDIF()
+endif(CGNS_USE_SHARED)
 
 #-----------------------------------------------------------------------------
 # Dashboard and Testing Settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,8 @@ if (CGNS_USE_SHARED)
   IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
      set(CMAKE_MACOSX_RPATH TRUE)
   ENDIF()
+else(CGNS_USE_SHARED)
+set(CMAKE_SKIP_RPATH TRUE)
 endif(CGNS_USE_SHARED)
 
 #-----------------------------------------------------------------------------
@@ -387,4 +389,3 @@ endif (CGNS_BUILD_TESTING)
 
 # Include the src directory
 add_subdirectory(src)
-


### PR DESCRIPTION
When not using shared libraries, do not do anything with RPATH on the
executables.