### PR TITLE
Change shared build rpath test symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,7 @@ endif (CGNS_ENABLE_HDF5 AND HDF5_NEED_MPI)
 # RPATH Management #
 ####################
 
-if (CGNS_USE_SHARED)
+if (CGNS_BUILD_SHARED)
   # use, i.e. don't skip the full RPATH for the build tree
   set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
@@ -363,9 +363,9 @@ if (CGNS_USE_SHARED)
   IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
      set(CMAKE_MACOSX_RPATH TRUE)
   ENDIF()
-else(CGNS_USE_SHARED)
+else(CGNS_BUILD_SHARED)
 set(CMAKE_SKIP_RPATH TRUE)
-endif(CGNS_USE_SHARED)
+endif(CGNS_BUILD_SHARED)
 
 #-----------------------------------------------------------------------------
 # Dashboard and Testing Settings


### PR DESCRIPTION
I think that the correct symbol to test should be `CGNS_BUILD_SHARED` instead of `CGNS_USE_SHARED`

With the test as it currently exists, my builds are not getting the correct rpath during the install of the tools (cgnsidff, cgnslist, ...), but if I use `CGNS_BUILD_SHARED`, then everything seems to work correctly and i get the correct rpath on the tools.  The `make install` step also shows that CMake is adding the runtime path to the installed tools, but I don't get the message with the current symbol in the test.  (The message is `Set runtime path of ...` during the install phase)