### PR TITLE
Upgrade minimum required version for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.8)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)


### PR DESCRIPTION
Nowadays Hdf5 requires cmake 3.12. Thus a little upgrade to require at least a 3.8 version of cmake in CGNS library seems sane.