### PR TITLE
Small improvements

### DIFF
--- a/src/Test_UserGuideCode/C_code/read_discreteface_str.c
+++ b/src/Test_UserGuideCode/C_code/read_discreteface_str.c
@@ -47,7 +47,7 @@ int main()
 /* clear f since only partial read */
     for (n=0; n<(9+2)*(16+2)*(20+2); n++)
     {
-      f[0][0][n] = -0.123456f;
+      (&f[0][0][0])[n] = -0.123456f;
     }
 
 /* READ FLOW SOLUTION FROM CGNS FILE */

--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -1662,6 +1662,7 @@ void ADFH_Create(const double  pid,
   hid_t hpid;
   hid_t gid;
   char *pname;
+  static const char empty_label[ADF_NAME_LENGTH+1] = "";
 #ifdef ADFH_DEBUG_ON
   H5L_info_t lkbuff;
 #endif
@@ -1699,7 +1700,7 @@ void ADFH_Create(const double  pid,
   else {
 #ifdef ADFH_NO_ORDER
     if (new_str_att(gid, A_NAME, pname, ADF_NAME_LENGTH, err) ||
-        new_str_att(gid, A_LABEL, "", ADF_NAME_LENGTH, err) ||
+        new_str_att(gid, A_LABEL, empty_label, ADF_NAME_LENGTH, err) ||
         new_str_att(gid, A_TYPE, ADFH_MT, 2, err) ||
         new_int_att(gid, A_FLAGS, mta_root->g_flags, err)) return;
 #else
@@ -1710,7 +1711,7 @@ void ADFH_Create(const double  pid,
     H5Literate_by_name(hpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, count_children, (void *)&order, H5P_DEFAULT);
 #endif
     if (new_str_att(gid, A_NAME, pname, ADF_NAME_LENGTH, err) ||
-        new_str_att(gid, A_LABEL, "", ADF_NAME_LENGTH, err) ||
+        new_str_att(gid, A_LABEL, empty_label, ADF_NAME_LENGTH, err) ||
         new_str_att(gid, A_TYPE, ADFH_MT, 2, err) ||
         new_int_att(gid, A_ORDER, order, err) ||
         new_int_att(gid, A_FLAGS, mta_root->g_flags, err)) return;
@@ -2021,6 +2022,8 @@ void ADFH_Database_Open(const char   *name,
 {
   hid_t fid, gid;
   char *format, buff[ADF_VERSION_LENGTH+1];
+  static const char root_name[ADF_NAME_LENGTH+1] = "HDF5 MotherNode";
+  static const char root_label[ADF_NAME_LENGTH+1] = "Root Node of HDF5 File";
   int i, pos, mode;
   hid_t g_propfileopen;
 
@@ -2249,8 +2252,8 @@ void ADFH_Database_Open(const char   *name,
     memset(buff, 0, ADF_VERSION_LENGTH+1);
     ADFH_Library_Version(buff, err);
     format = native_format();
-    if (new_str_att(gid, A_NAME, "HDF5 MotherNode", ADF_NAME_LENGTH, err) ||
-        new_str_att(gid, A_LABEL, "Root Node of HDF5 File", ADF_NAME_LENGTH, err) ||
+    if (new_str_att(gid, A_NAME, root_name, ADF_NAME_LENGTH, err) ||
+        new_str_att(gid, A_LABEL, root_label, ADF_NAME_LENGTH, err) ||
         new_str_att(gid, A_TYPE, ADFH_MT, 2, err) ||
         new_str_data(gid, D_FORMAT, format, (int)strlen(format), err) ||
         new_str_data(gid, D_VERSION, buff, ADF_VERSION_LENGTH, err)) {

--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -1539,6 +1539,7 @@ void ADFH_Set_Label(const double  id,
                     int          *err)
 {
   hid_t hid;
+  char label_name[ADF_NAME_LENGTH+1];
 
   to_HDF_ID(id, hid);
 
@@ -1556,7 +1557,8 @@ void ADFH_Set_Label(const double  id,
     set_error(ADFH_ERR_LINK_DATA, err);
     return;
   }
-  set_str_att(hid, A_LABEL, label, err);
+  strcpy(label_name, label);
+  set_str_att(hid, A_LABEL, label_name, err);
 }
 
 /* ----------------------------------------------------------------- */

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -257,7 +257,9 @@ const char * AverageInterfaceTypeName[NofValidAverageInterfaceTypes] =
 int n_open = 0;
 int cgns_file_size = 0;
 int file_number_offset = 0;
-int VersionList[] = {3210, 3200,
+int VersionList[] = {4200,
+                     4110, 4100, 4000,
+                     3210, 3200,
                      3140, 3130, 3110, 3100,
                      3080, 3000,
                      2550, 2540, 2530, 2520, 2510, 2500,
@@ -530,8 +532,8 @@ int cg_version(int file_number, float *FileVersion)
     if (cgi_get_nodes(cg->rootid, "CGNSLibraryVersion_t", &nnod, &id))
         return CG_ERROR;
     if (nnod==0) {
-        cg->version=1050;
-        *FileVersion= (float) 1.05;
+        cg->version=3200;
+        *FileVersion= (float) 3.20;
     } else if (nnod!=1) {
         cgi_error("More then one CGNSLibraryVersion_t node found under ROOT.");
         return CG_ERROR;

--- a/src/cgnstools/cgnsview/cgnsview.bat
+++ b/src/cgnstools/cgnsview/cgnsview.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal
 
+set HDF5_USE_FILE_LOCKING="FALSE"
 set dir=%~dps0
 if exist "%dir%cgconfig.bat" (
   call %dir%cgconfig.bat

--- a/src/cgnstools/cgnsview/cgnsview.sh
+++ b/src/cgnstools/cgnsview/cgnsview.sh
@@ -4,6 +4,9 @@
 
 dir=`dirname $0`
 
+# To let other tools access the file while cgnsview is running
+export HDF5_USE_FILE_LOCKING="FALSE"
+
 # source the setup script
 
 for d in $dir $dir/cgnstools $dir/.. ; do

--- a/src/tests/test_family_treef.F90
+++ b/src/tests/test_family_treef.F90
@@ -32,7 +32,7 @@
 ! ----  WRITING TESTS  ----
 
       outfile = "family_tree_f90.cgns"
-      call unlink( outfile )
+      !call unlink( outfile )
       ! write(*, *) 'Create file'
       call cg_open_f(outfile, CG_MODE_WRITE, cgfile, ierr)
       if (ierr .ne. CG_OK) call cg_error_exit_f


### PR DESCRIPTION
- Add environment variable to prevent cgnsview from locking CGNS/HDF5 files and let other tools like cgnscheck do their job
- Comment unlink in fortran test that creates problem on some platforms
- Rewrite initialization of stack array to remove GCC warning
- Add some missing CGNS library versions.
- Add a strcpy to prevent overflow with label shorter than ADF_NAME_LENGTH. (Internally it seems that label attribute has a fixed size of same length as the name attribute.)