### PR TITLE
Fix so will compile with JFC_PATCH_2015_2 enabled

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -2167,6 +2167,8 @@ void ADFH_Database_Open(const char   *name,
     set_error(TOO_MANY_ADF_FILES_OPENED, err);
     return;
   }
+	
+  g_propfileopen = H5Pcreate(H5P_FILE_ACCESS);
 
   /* Patch from Manuel Gageik on IBM BLUEgene/Q systems for better cgp_open performance. */
 #ifdef JFC_PATCH_2015_2
@@ -2195,7 +2197,6 @@ void ADFH_Database_Open(const char   *name,
 
 #endif
 
-  g_propfileopen = H5Pcreate(H5P_FILE_ACCESS);
 #ifdef ADFH_H5F_CLOSE_STRONG
   /* set access property to close all open accesses when file closed */
   H5Pset_fclose_degree(g_propfileopen, H5F_CLOSE_STRONG);


### PR DESCRIPTION
Was testing some file-open scaling behavior and wanted to see if the code in the `#ifdef JFC_PATCH_2015_2` blocks made any difference, but the creation of `g_propfileopen` was in the wrong place.

There is also an issue with `tconv` and `bkg` being shadowed in the later call at line 2253 but that is not fixed here...