### PR TITLE
clear cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,8 +377,8 @@ endif(CGNS_BUILD_SHARED)
 #-----------------------------------------------------------------------------
 option (CGNS_BUILD_TESTING "Build CGNS Testing" OFF)
 if (CGNS_BUILD_TESTING)
-  set (DART_TESTING_TIMEOUT 1200
-      CACHE INTEGER
+  set (DART_TESTING_TIMEOUT "1200"
+      CACHE STRING
       "Timeout in seconds for each test (default 1200=20minutes)"
   )
   enable_testing ()


### PR DESCRIPTION
INTEGER is not valid anymore, see : https://cmake.org/cmake/help/latest/command/set.html?highlight=set#set-cache-entry