### PR TITLE
CGNS-249 clean-up, fixed typo and removed remaining numbered DO loops

### DIFF
--- a/src/examples/fortran/Test1/cgmodify.F90
+++ b/src/examples/fortran/Test1/cgmodify.F90
@@ -111,12 +111,15 @@
                            'DiscreteData_t', discr_no, 'end')
             if (ier .eq. ERROR) call cg_error_exit_f
 
-	    do 123 k=1, size(3)
-            do 123 j=1, size(2)
-            do 123 i=1, size(1)
-                pos = i + (j-1)*size(1) + (k-1)*size(1)*size(2)
-	        data(pos) = pos	! * make up some dummy data
- 123	    continue
+	    DO k=1, SIZE(3)
+               DO j=1, SIZE(2)
+                  DO i=1, SIZE(1)
+                     pos = i + (j-1)*SIZE(1) + (k-1)*SIZE(1)*SIZE(2)
+                     DATA(pos) = pos	! * make up some dummy data
+                  ENDDO
+               ENDDO
+            ENDDO
+
 	    call cg_array_write_f('arrayname', CGNS_ENUMV(RealSingle), index_dim, &
                                    size, data, ier)
             if (ier .eq. ERROR) call cg_error_exit_f
@@ -147,11 +150,12 @@
 	    if (ier .eq. ERROR) call cg_error_exit_f
 
 ! *** general connectivity
-	    do 100 n=1, 5
-	    do 100 i=1,3
-	        pnts(i,n)=i		! * dummy data
-		donor_pnts(i,n)=i*2
- 100        continue
+            DO n=1, 5
+               DO i=1,3
+                  pnts(i,n)=i		! * dummy data
+                  donor_pnts(i,n)=i*2
+               ENDDO
+            ENDDO
 	  ! create a point matching connectivity
 	    call cg_conn_write_f(cg, base_no, zone_no, 'Connect#1', &
                 CGNS_ENUMV(Vertex), CGNS_ENUMV(Abutting1to1), CGNS_ENUMV(PointList), 5_cgsize_t, pnts, &

--- a/src/examples/fortran/Test_PartRdWr/cgwrite.F90
+++ b/src/examples/fortran/Test_PartRdWr/cgwrite.F90
@@ -63,8 +63,6 @@
         coordname(2) = 'CoordinateY'
         coordname(3) = 'CoordinateZ'
 
-!234567890!234567890!234567890!234567890!234567890!234567890!23456789012
-
 ! write coordinate data in 2 separate calls
 
 ! Set the ranges for the first partial write of the Coordinate data
@@ -74,12 +72,12 @@
 ! create coordinate data(10x10x10 box with 3x3x3 equidistant nodes)
         do coord=1,phys_dim
             pos = 0
-            do 20 i= rmin, rmax
-                pos = pos + 1
-                if (coord.eq.1) data_double(pos) = i
-                if (coord.eq.2) data_double(pos) = -i
-                if (coord.eq.3) data_double(pos) = i
- 20         continue
+            DO i= rmin, rmax
+               pos = pos + 1
+               IF (coord.EQ.1) data_double(pos) = i
+               IF (coord.EQ.2) data_double(pos) = -i
+               IF (coord.EQ.3) data_double(pos) = i
+            ENDDO
 
             call cg_coord_partial_write_f(cg, base, zone, CGNS_ENUMV(RealDouble), &
                         coordname(coord), rmin, rmax, data_double, C, &
@@ -96,12 +94,12 @@
 
         do coord=1,phys_dim
             pos = 0
-            do 21 i=rmin, rmax
-                pos = pos + 1
-                if (coord.eq.1) data_double(pos) = -i
-                if (coord.eq.2) data_double(pos) = i
-                if (coord.eq.3) data_double(pos) = -i
- 21          continue
+            DO i=rmin, rmax
+               pos = pos + 1
+               IF (coord.EQ.1) data_double(pos) = -i
+               IF (coord.EQ.2) data_double(pos) = i
+               IF (coord.EQ.3) data_double(pos) = -i
+            ENDDO
 
             call cg_coord_partial_write_f(cg, base, zone, CGNS_ENUMV(RealDouble), &
                         coordname(coord), rmin, rmax, data_double, C, &

--- a/src/examples/fortran/Test_mixed_elements/cgmodify.F90
+++ b/src/examples/fortran/Test_mixed_elements/cgmodify.F90
@@ -65,15 +65,16 @@
 
 ! create coordinate data(10x10x10 box with 3x3x3 equidistant nodes)
         do coord=1,phys_dim
-            do 20 k=1, 3
-            do 20 j=1, 3
-            do 20 i=1, 3
-                pos = i + (j-1)*3 + (k-1)*9
-                if (coord.eq.1) data_double(pos) = (i-1)*5
-                if (coord.eq.2) data_double(pos) = (j-1)*5
-                if (coord.eq.3) data_double(pos) = (k-1)*5
- 20         continue
-!234567890!234567890!234567890!234567890!234567890!234567890!23456789012
+           DO k=1, 3
+              DO j=1, 3
+                 DO i=1, 3
+                    pos = i + (j-1)*3 + (k-1)*9
+                    IF (coord.EQ.1) data_double(pos) = (i-1)*5
+                    IF (coord.EQ.2) data_double(pos) = (j-1)*5
+                    IF (coord.EQ.3) data_double(pos) = (k-1)*5
+                 ENDDO
+              ENDDO
+           ENDDO
 
 ! GOTO GridCoordinatesNode & write DataArray
             call cg_goto_f(cg, base, ier, 'Zone_t', zone, &

--- a/src/examples/fortran/Test_mixed_elements/cgwrite.F90
+++ b/src/examples/fortran/Test_mixed_elements/cgwrite.F90
@@ -66,15 +66,16 @@
 
 ! create coordinate data(10x10x10 box with 3x3x3 equidistant nodes)
         do coord=1,phys_dim
-            do 20 k=1, 3
-            do 20 j=1, 3
-            do 20 i=1, 3
-                pos = i + (j-1)*3 + (k-1)*9
-                if (coord.eq.1) data_double(pos) = (i-1)*5
-                if (coord.eq.2) data_double(pos) = (j-1)*5
-                if (coord.eq.3) data_double(pos) = (k-1)*5
- 20         continue
-!234567890!234567890!234567890!234567890!234567890!234567890!23456789012
+           DO k=1, 3
+              DO j=1, 3
+                 DO i=1, 3
+                    pos = i + (j-1)*3 + (k-1)*9
+                    IF (coord.EQ.1) data_double(pos) = (i-1)*5
+                    IF (coord.EQ.2) data_double(pos) = (j-1)*5
+                    IF (coord.EQ.3) data_double(pos) = (k-1)*5
+                 ENDDO
+              ENDDO
+           ENDDO
 
 ! GOTO GridCoordinatesNode & write DataArray
             call cg_goto_f(cg, base, ier, 'Zone_t', zone, &

--- a/src/examples/fortran/Test_mixed_grid/cgmodify.F90
+++ b/src/examples/fortran/Test_mixed_grid/cgmodify.F90
@@ -114,15 +114,17 @@
 
 ! create coordinate data
             do coord=1,phys_dim
-                do 20 k=1, 3
-                do 20 j=1, 3
-                do 20 i=1, 3
-                    pos = i + (j-1)*3 + (k-1)*9
-                    if (coord.eq.1) data_double(pos) = (i-1)*5 + &
-                        (zone-1)*10
-                    if (coord.eq.2) data_double(pos) = (j-1)*5
-                    if (coord.eq.3) data_double(pos) = (k-1)*5
- 20             continue
+               DO k=1, 3
+                  DO j=1, 3
+                     DO i=1, 3
+                        pos = i + (j-1)*3 + (k-1)*9
+                        IF (coord.EQ.1) data_double(pos) = (i-1)*5 + &
+                             (zone-1)*10
+                        IF (coord.EQ.2) data_double(pos) = (j-1)*5
+                        IF (coord.EQ.3) data_double(pos) = (k-1)*5
+                     ENDDO
+                  ENDDO
+               ENDDO
 
 ! GOTO GridCoordinatesNode & write DataArray
                 call cg_goto_f(cg, base, ier, 'Zone_t', zone, &
@@ -290,20 +292,22 @@
 
             ! Generate HEXA_8 Element Connectivity
                 n=0
-                do 30 k=1,2
-                do 30 j=1,2
-                do 30 i=1,2
-                    n=n+1
-                    pos = i + (j-1)*3 + (k-1)*9
-                    element(1,n) = pos
-                    element(2,n) = pos+1
-                    element(3,n) = pos+4
-                    element(4,n) = pos+3
-                    element(5,n) = pos+9
-                    element(6,n) = pos+10
-                    element(7,n) = pos+13
-                    element(8,n) = pos+12
- 30             continue
+                DO k=1,2
+                   DO j=1,2
+                      DO i=1,2
+                         n=n+1
+                         pos = i + (j-1)*3 + (k-1)*9
+                         element(1,n) = pos
+                         element(2,n) = pos+1
+                         element(3,n) = pos+4
+                         element(4,n) = pos+3
+                         element(5,n) = pos+9
+                         element(6,n) = pos+10
+                         element(7,n) = pos+13
+                         element(8,n) = pos+12
+                      ENDDO
+                   ENDDO
+                ENDDO
 
 		call cg_section_write_f(cg, base, zone, &
                   'VolumeElements', CGNS_ENUMV(HEXA_8), 1, 8, 0, &

--- a/src/examples/fortran/Test_mixed_grid/cgwrite.F90
+++ b/src/examples/fortran/Test_mixed_grid/cgwrite.F90
@@ -119,15 +119,17 @@
 
 ! create coordinate data
             do coord=1,phys_dim
-                do 20 k=1, 3
-                do 20 j=1, 3
-                do 20 i=1, 3
-                    pos = i + (j-1)*3 + (k-1)*9
-                    if (coord.eq.1) data_double(pos) = (i-1)*5 + &
-                        (zone-1)*10
-                    if (coord.eq.2) data_double(pos) = (j-1)*5
-                    if (coord.eq.3) data_double(pos) = (k-1)*5
- 20             continue
+               DO k=1, 3
+                  DO j=1, 3
+                     DO i=1, 3
+                        pos = i + (j-1)*3 + (k-1)*9
+                        IF (coord.EQ.1) data_double(pos) = (i-1)*5 + &
+                             (zone-1)*10
+                        IF (coord.EQ.2) data_double(pos) = (j-1)*5
+                        IF (coord.EQ.3) data_double(pos) = (k-1)*5
+                     ENDDO
+                  ENDDO
+               ENDDO
 
 ! GOTO GridCoordinatesNode & write DataArray
                 call cg_goto_f(cg, base, ier, 'Zone_t', zone, &
@@ -295,20 +297,22 @@
 
             ! Generate HEXA_8 Element Connectivity
                 n=0
-                do 30 k=1,2
-                do 30 j=1,2
-                do 30 i=1,2
-                    n=n+1
-                    pos = i + (j-1)*3 + (k-1)*9
-                    element(1,n) = pos
-                    element(2,n) = pos+1
-                    element(3,n) = pos+4
-                    element(4,n) = pos+3
-                    element(5,n) = pos+9
-                    element(6,n) = pos+10
-                    element(7,n) = pos+13
-                    element(8,n) = pos+12
- 30             continue
+                DO k=1,2
+                   DO j=1,2
+                      DO i=1,2
+                         n=n+1
+                         pos = i + (j-1)*3 + (k-1)*9
+                         element(1,n) = pos
+                         element(2,n) = pos+1
+                         element(3,n) = pos+4
+                         element(4,n) = pos+3
+                         element(5,n) = pos+9
+                         element(6,n) = pos+10
+                         element(7,n) = pos+13
+                         element(8,n) = pos+12
+                      ENDDO
+                   ENDDO
+                ENDDO
 
 		call cg_section_write_f(cg, base, zone, &
                   'VolumeElements', CGNS_ENUMV(HEXA_8), 1_cgsize_t, 8_cgsize_t, 0, &

--- a/src/examples/fortran/Test_motion/cgwrite.F90
+++ b/src/examples/fortran/Test_motion/cgwrite.F90
@@ -305,12 +305,14 @@
             if (ier .ne. ALL_OK) call cg_error_exit_f
 
 ! *** make up some dummy GridVelocityX values just for the test:
-            do 13 k=1, size(3)
-            do 13 j=1, size(2)
-            do 13 i=1, size(1)
-                pos = i + (j-1)*size(1) + (k-1)*size(1)*size(2)
-		GridVelocity(pos) = pos
- 13	    continue
+            DO k=1, SIZE(3)
+              DO j=1, SIZE(2)
+                 DO  i=1, SIZE(1)
+                    pos = i + (j-1)*SIZE(1) + (k-1)*SIZE(1)*SIZE(2)
+                    GridVelocity(pos) = pos
+                 ENDDO
+              ENDDO
+           ENDDO
 
 ! *** Add a DataArray_t 'GridVelocityX' under ArbitraryGridMotion_t
             !call cg_array_write_f('GridVelocityX', CGNS_ENUMV(RealSingle),

--- a/src/ptests/fexample.F90
+++ b/src/ptests/fexample.F90
@@ -40,7 +40,7 @@ PROGRAM fexample
   IF (ierr .NE. CG_OK) CALL cgp_error_exit_f
   CALL cg_base_write_f(F, 'Base', 3, 3, B, ierr)
   IF (ierr .NE. CG_OK) CALL cgp_error_exit_f
-  CALL cg_zone_write_f(F, B, 'CGNS_ENUMV(Zone)', sizes, CGNS_ENUMV(Unstructured), Z, ierr)
+  CALL cg_zone_write_f(F, B, 'Zone', sizes, CGNS_ENUMV(Unstructured), Z, ierr)
   IF (ierr .NE. CG_OK) CALL cgp_error_exit_f
 
 !---- print info
@@ -145,7 +145,7 @@ PROGRAM fexample
   IF (ierr .NE. CG_OK) CALL cgp_error_exit_f
 
 !---- create user data under the zone and duplicate solution data
-  CALL cg_goto_f(F, B, ierr, 'CGNS_ENUMV(Zone)_t', 1, 'end')
+  CALL cg_goto_f(F, B, ierr, 'Zone_t', 1, 'end')
   IF (ierr .NE. CG_OK) CALL cgp_error_exit_f
   CALL cg_user_data_write_f('User Data', ierr)
   IF (ierr .NE. CG_OK) CALL cgp_error_exit_f


### PR DESCRIPTION
Fixed typo in fexample_f and removed warnings reported due to number DO loops. CGNS-249