### PR TITLE
cgnstypes: avoid defining `stat`

### DIFF
--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -73,10 +73,12 @@ cgns_io_ctx_t ctx_cgio = { .hdf5_access = "NATIVE",
 
 #if CG_HAVE_STAT64_STRUCT
 #ifdef _WIN32
-#define stat _stat64
+#define cgns_stat _stat64
 #else
-#define stat stat64
+#define cgns_stat stat64
 #endif
+#else
+#define cgns_stat stat
 #endif
 
 /* Flag for contiguous or compact HDF5 storage */
@@ -228,7 +230,7 @@ static int rewrite_file (int cginp, const char *filename)
     cgns_io *input, *output;
     char *tmpfile, *linkfile = NULL;
 #ifdef S_IFLNK
-    struct stat st;
+    struct cgns_stat st;
 #endif
 
     input = get_cgnsio(cginp, 0);
@@ -589,11 +591,11 @@ int cgio_check_file (const char *filename, int *file_type)
     char buf[32];
     FILE *fp;
     static char *HDF5sig = "\211HDF\r\n\032\n";
-    struct stat st;
+    struct cgns_stat st;
 
     int mpibuf[2], err = CGIO_ERR_NONE;
 
-    if (ACCESS (filename, 0) || stat (filename, &st) ||
+    if (ACCESS (filename, 0) || cgns_stat (filename, &st) ||
         S_IFREG != (st.st_mode & S_IFREG)) {
         last_err = CGIO_ERR_NOT_FOUND;
         return last_err;

--- a/src/cgnstypes.h.in
+++ b/src/cgnstypes.h.in
@@ -40,11 +40,6 @@
 #define CG_MAX_INT32 0x7FFFFFFF
 #ifdef _WIN32
 # define CG_LONG_T __int64
-#ifdef _MSC_VER
-# if CG_BUILD_64BIT
-#  define stat _stat32i64
-# endif
-#endif
 #else
 # define CG_LONG_T @CGLONGT@
 #endif

--- a/src/tools/cgnscompress.c
+++ b/src/tools/cgnscompress.c
@@ -9,18 +9,21 @@
 
 #if CG_HAVE_STAT64_STRUCT
 #ifdef _WIN32
-#define stat _stat64
+#define cgns_stat _stat64
 #else
-#define stat stat64
+#define cgns_stat stat64
 #endif
+#else
+#define cgns_stat stat
 #endif
+
 
 int main (int argc, char **argv)
 {
     char *inpfile, *outfile;
     int inpcg;
     size_t inpsize, outsize;
-    struct stat st;
+    struct cgns_stat st;
 
     if (argc < 2 || argc > 3) {
         fprintf(stderr, "usage: cgnscompress InputFile [OutputFile]\n");
@@ -29,7 +32,7 @@ int main (int argc, char **argv)
     inpfile = argv[1];
     outfile = argv[argc-1];
 
-    if (stat(inpfile, &st)) {
+    if (cgns_stat(inpfile, &st)) {
         fprintf (stderr, "can't stat %s\n", inpfile);
         exit (1);
     }
@@ -40,7 +43,7 @@ int main (int argc, char **argv)
     if (cgio_compress_file (inpcg, outfile))
         cgio_error_exit("cgio_compress_file");
 
-    if (stat(outfile, &st)) {
+    if (cgns_stat(outfile, &st)) {
         fprintf (stderr, "can't stat %s\n", outfile);
         exit (1);
     }


### PR DESCRIPTION
This conflicts with `struct stat` that comes in `sys/stat.h` header with
MSVC. Older compilers may have other things, but it is just not valid to
do it without more sophisticated checks.