### PR TITLE
PATCH: special handling for STARCCM+ headers

### DIFF
--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -624,7 +624,15 @@ int cgio_check_file (const char *filename, int *file_type)
     fclose (fp);
 
     /* check for ADF */
-    if (0 == strncmp (&buf[4], "ADF Database Version", 20)) {
+    /*
+     * CD-ADAPCO (now Siemens) replaced " Version" with ">"
+     * to detect detect binary/ascii conversion etc.
+     *
+     * Accept that too so that we can view .ccm files
+     */
+    if (
+           0 == strncmp (&buf[4], "ADF Database Version", 20)
+        || 0 == strncmp (&buf[4], "ADF Database>", 13)) {
       *file_type = CGIO_FILE_ADF;
       err = set_error(CGIO_ERR_NONE);
     } else {


### PR DESCRIPTION
In starccm+ files, which are actually ADF format, 
the magic characters have `ADF Database>^A^B^C^D^E^F^G^H` instead of `ADF Database Version`.

AFAIK this was changed to detect binary/ascii transmission problems, but it could have been some other reason.
In any case, adding an extra check for these lets us use `cgnslist` without any problem. The risk of a false positive on other files is absolutely minimal at best.

I have been dragging around this patch for a very long time, so probably time to finally push it upstream.
