### PR TITLE
Set the default file_type in cg_open only when in write mode

### DIFF
--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -84,6 +84,8 @@ cgns_io_ctx_t ctx_cgio = { .hdf5_access = "NATIVE",
 /* Flag for contiguous or compact HDF5 storage */
 extern int HDF5storage_type;
 
+extern int cgns_filetype;
+
 typedef struct {
     int type;
     int mode;
@@ -750,7 +752,12 @@ int cgio_open_file (const char *filename, int file_mode,
         case 'w':
         case 'W':
             UNLINK(filename);
-            type = file_type;
+
+            /* set default file type if not done */
+            if (file_type == CG_FILE_NONE)
+                cg_set_file_type(CG_FILE_NONE);
+
+            type = file_type = cgns_filetype;
             file_mode = CGIO_MODE_WRITE;
             fmode = "NEW";
             break;

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -752,11 +752,6 @@ int cgio_open_file (const char *filename, int file_mode,
         case 'w':
         case 'W':
             UNLINK(filename);
-
-            /* set default file type if not done */
-            if (file_type == CG_FILE_NONE)
-                cg_set_file_type(CG_FILE_NONE);
-
             type = file_type = cgns_filetype;
             file_mode = CGIO_MODE_WRITE;
             fmode = "NEW";

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -84,8 +84,6 @@ cgns_io_ctx_t ctx_cgio = { .hdf5_access = "NATIVE",
 /* Flag for contiguous or compact HDF5 storage */
 extern int HDF5storage_type;
 
-extern int cgns_filetype;
-
 typedef struct {
     int type;
     int mode;
@@ -752,7 +750,7 @@ int cgio_open_file (const char *filename, int file_mode,
         case 'w':
         case 'W':
             UNLINK(filename);
-            type = file_type = cgns_filetype;
+            type = file_type;
             file_mode = CGIO_MODE_WRITE;
             fmode = "NEW";
             break;

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -361,6 +361,7 @@ int cg_open(const char *filename, int mode, int *file_number)
             }
             break;
         case CG_MODE_WRITE:
+            /* unlink is now done in cgio_open_file */
             /* set default file type if not done */
             if (cgns_filetype == CG_FILE_NONE)
                 cg_set_file_type(CG_FILE_NONE);

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -368,10 +368,6 @@ int cg_open(const char *filename, int mode, int *file_number)
             return CG_ERROR;
     }
 
-    /* set default file type if not done */
-    if (cgns_filetype == CG_FILE_NONE)
-        cg_set_file_type(CG_FILE_NONE);
-
     /* Open CGNS file */
     if (cgio_open_file(filename, mode, cgns_filetype, &cgio)) {
         cg_io_error("cgio_open_file");

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -361,7 +361,9 @@ int cg_open(const char *filename, int mode, int *file_number)
             }
             break;
         case CG_MODE_WRITE:
-            /* unlink is now done in cgio_open_file */
+            /* set default file type if not done */
+            if (cgns_filetype == CG_FILE_NONE)
+                cg_set_file_type(CG_FILE_NONE);
             break;
         default:
             cgi_error("Unknown opening file mode: %d ??",mode);


### PR DESCRIPTION
Currently, the default file_type is set prior to calling **cgio_open_file** from **cg_open** if cgns_filetype has not been specified. This leads to the error message "cgio_open_file:not a HDF5 file - required for parallel" when an ADF based file is opened and the CGNS library has been compiled with support for HDF5 and parallel output.

By now only setting the default file_type when a new file is to be created within cgio_open_file, we can avoid the above problem without changing the default behavior of the code.

Moving the setting of the file_type into cgio_open_file breaks some of the tests that explicitly call this routine. So now, just limit the default initialization of file_type within cg_open to when a new file is to be created.

ref. CGNS-266