### PR TITLE
Fixed clang -Wstrict-prototypes warnings

### DIFF
--- a/src/adf/ADF_internals.h
+++ b/src/adf/ADF_internals.h
@@ -525,7 +525,7 @@ extern  void    ADFI_increment_array(
             cgulong_t *element_offset,
             int *error_return ) ;
 
-extern  void    ADFI_is_block_in_core() ;
+extern  void    ADFI_is_block_in_core(void) ;
 
 extern  void    ADFI_little_endian_to_cray(
 	    const char from_format,
@@ -591,7 +591,7 @@ extern  void    ADFI_read_data_translated(
             char *data,
             int *error_return ) ;
 
-extern  void    ADFI_read_disk_block() ;
+extern  void    ADFI_read_disk_block(void) ;
 
 extern  void    ADFI_read_disk_pointer_from_disk(
             const unsigned int file_index,
@@ -707,7 +707,7 @@ extern  void    ADFI_write_data_translated(
             const char *data,
             int *error_return ) ;
 
-extern  void    ADFI_write_disk_block() ;
+extern  void    ADFI_write_disk_block(void) ;
 
 extern  void    ADFI_write_disk_pointer_2_disk(
             const unsigned int file_index,

--- a/src/cg_malloc.c
+++ b/src/cg_malloc.c
@@ -63,9 +63,9 @@ void cgfree(void *freedata) {
     free_calls++;
 }
 
-size_t cgmemnow() {return mem_now;}
-size_t cgmemmax() {return mem_max;}
+size_t cgmemnow(void) {return mem_now;}
+size_t cgmemmax(void) {return mem_max;}
 
-size_t cgalloccalls() {return alloc_calls;}
-size_t cgfreecalls()  {return free_calls;}
+size_t cgalloccalls(void) {return alloc_calls;}
+size_t cgfreecalls(void)  {return free_calls;}
 

--- a/src/cg_malloc.h
+++ b/src/cg_malloc.h
@@ -11,9 +11,9 @@ extern void  *cgrealloc(void *,size_t);
 extern void  *cgcalloc(size_t,size_t);
 extern void   cgfree(void *);
 
-extern size_t cgmemnow();
-extern size_t cgmemmax();
-extern size_t cgalloccalls();
-extern size_t cgfreecalls();
+extern size_t cgmemnow(void);
+extern size_t cgmemmax(void);
+extern size_t cgalloccalls(void);
+extern size_t cgfreecalls(void);
 
 #endif

--- a/src/cgns_header.h
+++ b/src/cgns_header.h
@@ -1034,8 +1034,8 @@ CGNSDLL cgns_subreg    *cgi_get_subreg   (cgns_file *cg, int B, int Z, int S);
 CGNSDLL int cgi_update_posit(int cnt, int *index, char **label);
 CGNSDLL int cgi_set_posit(int fn, int B, int n, int *index, char **label);
 CGNSDLL int cgi_posit_id(double *posit_id);
-CGNSDLL cgns_posit *cgi_get_posit();
-CGNSDLL int cgi_posit_index_dim();
+CGNSDLL cgns_posit *cgi_get_posit(void);
+CGNSDLL int cgi_posit_index_dim(void);
 
 /* retrieve memory address of multiple patch children knowing their parent label
    (posit_label) and their parent memory address (posit) */
@@ -1067,7 +1067,7 @@ cgns_dataset * cgi_bcdataset_address(int local_mode, int given_no,
     char const *given_name, int *ier);
 
 /* read CGNS file into internal database */
-int cgi_read();
+int cgi_read(void);
 int cgi_read_base(cgns_base *base);
 int cgi_read_zone(cgns_zone *zone);
 int cgi_read_zonetype(double parent_id, char_33 parent_name, CGNS_ENUMT(ZoneType_t) *type);

--- a/src/cgns_io.h
+++ b/src/cgns_io.h
@@ -121,7 +121,7 @@ CGEXTERN int cgio_configure (
     void *value
 );
 
-CGEXTERN void cgio_cleanup ();
+CGEXTERN void cgio_cleanup (void);
 
 CGEXTERN int cgio_check_file (
     const char *filename,

--- a/src/tests/test_complex.c
+++ b/src/tests/test_complex.c
@@ -52,10 +52,10 @@ char errmsg[256];
 
 static float exponents[5] = {0, 1, 0, 0, 0};
 
-void init_data();
-void write_structured();
-void test_complex_solution();
-void release_data();
+void init_data(void);
+void write_structured(void);
+void test_complex_solution(void);
+void release_data(void);
 
 void error_exit (char *where)
 {

--- a/src/tests/test_ver31.c
+++ b/src/tests/test_ver31.c
@@ -46,9 +46,9 @@ char errmsg[256];
 
 static float exponents[5] = {0, 1, 0, 0, 0};
 
-void init_data();
-void write_structured(), write_unstructured();
-void test_zconn(), test_subreg();
+void init_data(void);
+void write_structured(void), write_unstructured(void);
+void test_zconn(void), test_subreg(void);
 
 void error_exit (char *where)
 {

--- a/src/tests/write_test.c
+++ b/src/tests/write_test.c
@@ -61,9 +61,9 @@ float *interp;
 
 char errmsg[128];
 
-void init_data();
-void write_structured(), write_unstructured();
-void write_mixed(), write_mismatched();
+void init_data(void);
+void write_structured(void), write_unstructured(void);
+void write_mixed(void), write_mismatched(void);
 
 void error_exit (char *where)
 {
@@ -281,7 +281,7 @@ void init_data()
     }
 }
 
-void write_reference ()
+void write_reference (void)
 {
     int n, i, ierr;
     cgsize_t dim = 1;
@@ -336,7 +336,7 @@ void write_reference ()
     }
 }
 
-void write_equationset ()
+void write_equationset (void)
 {
     int n, diff[6];
     cgsize_t dim = 1;


### PR DESCRIPTION
Clang is considering making this warning an error by default: https://discourse.llvm.org/t/rfc-enabling-wstrict-prototypes-by-default-in-c/60521