### PR TITLE
Increase maximum open file limit

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -156,8 +156,7 @@ printf aaa ; printf("\n"); fflush(stdout);
 #define ADFH_MODE_RDO 3
 
 /* the following keeps track of open and mounted files */
-
-#define ADFH_MAXIMUM_FILES 128
+#define ADFH_MAXIMUM_FILES 1024
 
 /* Start to prepare re-entrance into lib, gather static variables in one global struct  */
 /* Then, you'll just have to handle struct with something else but a static... */


### PR DESCRIPTION
Increase the maximum open file limit to 1024 which is a typical value for many operating systems.  Since some OS's have higher or lower limits, it would be nice to make this configurable at some point, but a hardwired value of 1024 fixes the main issue that I am seeing right now...