### PR TITLE
ADFH: check for the H5L info structure type directly

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -61,6 +61,18 @@ static int CompressData = -1;
 
 #define ADFH_CONFIG_DEFAULT 0
 
+#if H5_VERSION_GE(1,10,3) && !defined(H5_USE_18_API) && !defined(H5_USE_16_API)
+#define ADFH_HDF5_HAVE_110_API 1
+#else
+#define ADFH_HDF5_HAVE_110_API 0
+#endif
+
+#if H5_VERSION_GE(1,12,0) && !defined(H5_USE_110_API) && !defined(H5_USE_18_API) && !defined(H5_USE_16_API)
+#define ADFH_HDF5_HAVE_112_API 1
+#else
+#define ADFH_HDF5_HAVE_112_API 0
+#endif
+
 /*** HDF5's CORE FILE DRIVER PARAMETERS ****/
 
 /* Enables using the core file driver */
@@ -292,7 +304,7 @@ if (mta_root == NULL){set_error(ADFH_ERR_ROOTNULL, err);return 1;}
 static herr_t gfind_by_name(hid_t, const char *, const H5L_info_t*, void *);
 static herr_t find_by_name(hid_t, const char *, const H5A_info_t*, void *);
 
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
 #define has_child(ID,NAME) H5Literate2(ID, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, gfind_by_name, (void *)NAME)
 #define has_data(ID)       H5Literate2(ID, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, gfind_by_name, (void *)D_DATA)
 #else
@@ -369,7 +381,7 @@ static hid_t get_file_id (hid_t id)
   int token_cmp;
   /* find the file ID from the root ID */
 
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
   if (H5Oget_info_by_name3(id, "/", &gstat, H5O_INFO_BASIC, H5P_DEFAULT) >=0) {
 #else
   if (H5Oget_info_by_name(id, "/", &gstat, H5P_DEFAULT) >=0) {
@@ -380,7 +392,7 @@ static hid_t get_file_id (hid_t id)
       if (objs == NULL) return fid;
       H5Fget_obj_ids(H5F_OBJ_ALL, H5F_OBJ_FILE, -1, objs);
       for (n = 0; n < nobj; n++) {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
         H5Oget_info_by_name3(objs[n], "/", &rstat, H5O_INFO_BASIC, H5P_DEFAULT);
         token_cmp = 1;
         if(gstat.fileno == rstat.fileno){
@@ -1056,7 +1068,7 @@ static herr_t compare_children(hid_t id, const char *name, const H5L_info_t *lin
 
   if (*name != D_PREFIX) {
     pstat = (H5O_info_t *)data;
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     if (H5Oget_info_by_name3(id, name, &stat, H5O_INFO_BASIC, H5P_DEFAULT) >= 0){
       token_cmp = 1;
       if(pstat->fileno == stat.fileno){
@@ -1163,7 +1175,7 @@ static hid_t open_link(hid_t id, int *err)
       }
   }
 #ifdef ADFH_DEBUG_ON
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
   H5Oget_info3(lid, &oinfo, H5O_INFO_BASIC);
 #else
   H5Oget_info(lid, &oinfo);
@@ -1271,7 +1283,7 @@ static herr_t delete_children(hid_t id, const char *name, const H5L_info_t* linf
   }
   else {
     ADFH_DEBUG(("delete_children loop"));
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     if (! is_link(id)) H5Literate_by_name2(id, name, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, delete_children, data, H5P_DEFAULT);
 #else
     if (! is_link(id)) H5Literate_by_name(id, name, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, delete_children, data, H5P_DEFAULT);
@@ -1431,7 +1443,7 @@ static herr_t fix_dimensions(hid_t id, const char *name, const H5L_info_t* linfo
 
   if (*name != D_PREFIX && (gid = H5Gopen2(id, name, H5P_DEFAULT)) >= 0 &&
      !get_str_att(gid, A_TYPE, type, &err) && strcmp(type, ADFH_LK)) {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     H5Literate2(gid, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, fix_dimensions, NULL);
 #else
     H5Literate(gid, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, fix_dimensions, NULL);
@@ -1559,7 +1571,7 @@ void ADFH_Move_Child(const double  pid,
 
   /* check that node is actually child of the parent */
 
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
   if (H5Oget_info_by_name3(hid, ".", &stat, H5O_INFO_BASIC, H5P_DEFAULT) < 0 ||
     !H5Literate2(hpid, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, compare_children, (void *)&stat)) {
 #else
@@ -1615,7 +1627,7 @@ void ADFH_Move_Child(const double  pid,
       set_int_att(hid, A_ORDER, new_order, err)) return;
 
   /*see if we need to decrement any node _orders under the old parent*/
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
   *err = H5Literate2(hpid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, fix_order, (void *)&old_order);
 #else
   *err = H5Literate(hpid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, fix_order, (void *)&old_order);
@@ -1801,7 +1813,7 @@ void ADFH_Create(const double  pid,
         new_int_att(gid, A_FLAGS, mta_root->g_flags, err)) return;
 #else
     int order = 0;
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     H5Literate2(hpid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, count_children, (void *)&order);
 #else
     H5Literate(hpid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, count_children, (void *)&order);
@@ -1847,7 +1859,7 @@ void ADFH_Delete(const double  pid,
 
   /* check that node is actually child of the parent */
 
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
   if (H5Oget_info_by_name3(hid, ".", &stat, H5O_INFO_BASIC, H5P_DEFAULT) < 0 ||
     !H5Literate2(hpid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, compare_children, (void *)&stat)){
 #else
@@ -1871,7 +1883,7 @@ void ADFH_Delete(const double  pid,
 
   if (! is_link(hid))
   {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     H5Literate2(hid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, delete_children, NULL);
 #else
     H5Literate(hid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, delete_children, NULL);
@@ -1886,7 +1898,7 @@ void ADFH_Delete(const double  pid,
   /* decrement node orders */
 
 #ifndef ADFH_NO_ORDER
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
   *err = H5Literate2(hpid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, fix_order, (void *)&old_order);
 #else
   *err = H5Literate(hpid, H5_INDEX_CRT_ORDER, H5_ITER_INC, NULL, fix_order, (void *)&old_order);
@@ -1915,7 +1927,7 @@ void ADFH_Number_of_Children(const double  id,
 
   *number = 0;
   if ((hid = open_node(id, err)) >= 0) {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     H5Literate2(hid, mta_root->link_create_order, H5_ITER_NATIVE, &gskip, count_children, (void *)number);
 #else
     H5Literate(hid, mta_root->link_create_order, H5_ITER_NATIVE, &gskip, count_children, (void *)number);
@@ -2023,7 +2035,7 @@ void ADFH_Children_Names(const double pid,
   /*initialize names to null*/
   memset(names, 0, (size_t)ilen*(size_t)name_length);
   if ((hpid = open_node(pid, err)) >= 0) {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     H5Literate2(hpid,H5_INDEX_CRT_ORDER,H5_ITER_INC,
                NULL,children_names,(void *)names);
 #else
@@ -2032,7 +2044,7 @@ void ADFH_Children_Names(const double pid,
 #endif
     if (names[0]==0)
     {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
       H5Literate2(hpid,H5_INDEX_NAME,H5_ITER_INC,
                  NULL,children_names,(void *)names);
 #else
@@ -2073,7 +2085,7 @@ void ADFH_Children_IDs(const double pid,
   mta_root->i_count = 0;
 #endif
   if ((hpid = open_node(pid, err)) >= 0) {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     H5Literate2(hpid,mta_root->link_create_order,H5_ITER_INC,
                NULL,children_ids,(void *)IDs);
 #else
@@ -2291,7 +2303,7 @@ void ADFH_Database_Open(const char   *name,
   else {
     /* Compatibility with V1.8 */
     H5Pset_libver_bounds(g_propfileopen,
-#if H5_VERSION_GE(1,10,3)
+#if ADFH_HDF5_HAVE_110_API
           H5F_LIBVER_V18, H5F_LIBVER_V18);
 #else
           H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
@@ -2409,7 +2421,7 @@ void ADFH_Database_Open(const char   *name,
     }
   }
   else {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
     if (H5Fis_accessible(name, H5P_DEFAULT) <= 0) {
 #else
     if (H5Fis_hdf5(name) <= 0) {
@@ -2460,7 +2472,7 @@ void ADFH_Database_Open(const char   *name,
 
 #ifdef ADFH_FORTRAN_INDEXING
     if (mode != ADFH_MODE_RDO && child_exists(gid, D_OLDVERS)) {
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
       H5Literate2(gid, mta_root->link_create_order, H5_ITER_INC, NULL, fix_dimensions, NULL);
 #else
       H5Literate(gid, mta_root->link_create_order, H5_ITER_INC, NULL, fix_dimensions, NULL);
@@ -2488,7 +2500,7 @@ void ADFH_Database_Valid(const char   *name,
     if (NULL == name || 0 == *name)
         *err = NULL_STRING_POINTER;
     else
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
         *err = H5Fis_accessible(name, H5P_DEFAULT);
 #else
         *err = H5Fis_hdf5(name);
@@ -2561,7 +2573,7 @@ void ADFH_Database_Delete(const char *name,
 {
   ADFH_DEBUG(("ADFH_Database_Delete [%s]",name));
 
-#if H5_VERSION_GE(1,12,0)
+#if ADFH_HDF5_HAVE_112_API
   if (H5Fis_accessible(name, H5P_DEFAULT) <=0)
 #else
   if (H5Fis_hdf5(name) <= 0)


### PR DESCRIPTION
Newer HDF5 builds can still choose to have old ABIs.