### PR TITLE
Add cgns-config.cmake file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,19 +372,19 @@ if (CGNS_ENABLE_HDF5)
   mark_as_advanced(CLEAR HDF5_NEED_ZLIB HDF5_NEED_SZIP HDF5_NEED_MPI)
 
   #Modern Target Library import if not defined
-  if (NOT TARGET hdf5::hdf5-${CG_HDF5_LINK_TYPE})
-    add_library(hdf5::hdf5-${CG_HDF5_LINK_TYPE} INTERFACE IMPORTED)
+  if (NOT TARGET hdf5-${CG_HDF5_LINK_TYPE})
+    add_library(hdf5-${CG_HDF5_LINK_TYPE} INTERFACE IMPORTED)
     string(REPLACE "-D" "" _hdf5_definitions "${HDF5_DEFINITIONS}")
-    set_target_properties(hdf5::hdf5-${CG_HDF5_LINK_TYPE} PROPERTIES
+    set_target_properties(hdf5-${CG_HDF5_LINK_TYPE} PROPERTIES
                           INTERFACE_LINK_LIBRARIES "${HDF5_LIBRARY}"
                           INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}"
                           INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
     if (CG_HDF5_LINK_TYPE STREQUAL "shared")
-      set_target_properties(hdf5::hdf5-${CG_HDF5_LINK_TYPE} PROPERTIES
+      set_target_properties(hdf5-${CG_HDF5_LINK_TYPE} PROPERTIES
                             INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_DYNAMIC_LIB)
 
     else()
-      set_target_properties(hdf5::hdf5-${CG_HDF5_LINK_TYPE} PROPERTIES
+      set_target_properties(hdf5-${CG_HDF5_LINK_TYPE} PROPERTIES
 			    INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_STATIC_LIB)
     endif()
   endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -577,7 +577,7 @@ add_library(cgns_static STATIC ${cgns_FILES} $<$<BOOL:${CGNS_ENABLE_FORTRAN}>:$<
 add_library(CGNS::cgns-static ALIAS cgns_static)
 # Needed to work around a CMake > 3.8 bug on Windows with MSVS and Intel Fortran
 set_property(TARGET cgns_static PROPERTY LINKER_LANGUAGE C)
-target_link_libraries(cgns_static PRIVATE $<$<BOOL:${CGNS_ENABLE_HDF5}>:hdf5::hdf5-${CG_HDF5_LINK_TYPE}>)
+target_link_libraries(cgns_static PRIVATE $<$<BOOL:${CGNS_ENABLE_HDF5}>:hdf5-${CG_HDF5_LINK_TYPE}>)
 
 # Build a shared version of the library
 if(CGNS_BUILD_SHARED)
@@ -594,7 +594,7 @@ if(CGNS_BUILD_SHARED)
     target_compile_definitions(cgns_shared INTERFACE -DUSE_DLL)
   endif ()
   if (CGNS_ENABLE_HDF5 AND HDF5_LIBRARY)
-    target_link_libraries(cgns_shared PUBLIC hdf5::hdf5-${CG_HDF5_LINK_TYPE} $<$<NOT:$<PLATFORM_ID:Windows>>:${CMAKE_DL_LIBS}>)
+    target_link_libraries(cgns_shared PUBLIC hdf5-${CG_HDF5_LINK_TYPE} $<$<NOT:$<PLATFORM_ID:Windows>>:${CMAKE_DL_LIBS}>)
     if(HDF5_NEED_ZLIB AND ZLIB_LIBRARY)
       target_link_libraries(cgns_shared PUBLIC ${ZLIB_LIBRARY})
     endif()
@@ -728,6 +728,18 @@ install(FILES ${headers}
 	DESTINATION include)
 
 #if (NOT CGNS_EXTERNALLY_CONFIGURE)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/cgns-config-version.cmake
+  VERSION ${CGNS_VERSION}
+  COMPATIBILITY SameMajorVersion )
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cgns-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/cgns-config.cmake
+  INSTALL_DESTINATION lib/cmake/cgns )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cgns-config-version.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/cgns-config.cmake
+	DESTINATION lib/cmake/cgns)
 install(EXPORT cgns-targets
 	FILE cgns-targets.cmake
 	NAMESPACE CGNS::

--- a/src/cgns-config.cmake.in
+++ b/src/cgns-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/cgns-targets.cmake")
+
+check_required_components(cgns)


### PR DESCRIPTION
This adds a cgns-config.cmake file to allow projects to use find_package(cgns).
It also adjust names of hdf5 libraries to link with to use names given by find_package(HDF5).