### PR TITLE
Fix for when using HDF5 1.14.3 and onward with NAG compiler.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,7 +142,7 @@ endif()
 # The NAG compiler needs an additional flag for Fortran calls to C APIs.
 #--------------------------------------------------------------------------
 if(CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
- SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -mismatch_all")
+ SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -mismatch_all -ieee=full")
 endif()
 
 ENABLE_LANGUAGE(Fortran)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1881,7 +1881,7 @@ if test "$withfortran" = "yes"; then
 #--------------------------------------------------------------------------
      fc_vendor="`$FC -V 2>&1 |grep 'NAG'`"
      if test X != "X$fc_vendor"; then
-       FFLAGS="$FFLAGS -mismatch_all"
+       FFLAGS="$FFLAGS -mismatch_all -ieee=full"
      fi
 fi
 #--------------------------------------------------------------------------


### PR DESCRIPTION
IEEE standard arithmetic enables software to raise exceptions such as overflow, division by zero, and other illegal operations without interrupting or halting the program flow. The HDF5 C library intentionally performs these exceptions. Therefore, the "-ieee=full" nagfor switch is necessary when compiling a program/tests with CGNS using the NAG compiler to avoid stopping on an exception.