### PR TITLE
Update cmake requirement

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql.yml
@@ -84,6 +84,6 @@ jobs:
         shell: bash
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/config-cgns.sh
+++ b/.github/workflows/config-cgns.sh
@@ -42,7 +42,7 @@ if [[ "$OS_NAME" = "linux" ]]; then
 # Do a different test set-up than the autotools build
   OPTS_CMAKE="$OPTS_CMAKE -D CGNS_ENABLE_LEGACY:BOOL=ON -D CGNS_ENABLE_64BIT:BOOL=OFF"
 else
-  OPTS_CMAKE="$OPTS_CMAKE -D CMAKE_OSX_ARCHITECTURES:STRING='arm64;x86_64'"
+  OPTS_CMAKE="$OPTS_CMAKE -D CMAKE_OSX_ARCHITECTURES:STRING=arm64"
 fi
 
 if [[ "$BUILD" == "cmake" ]]; then

--- a/.github/workflows/config-cgns.sh
+++ b/.github/workflows/config-cgns.sh
@@ -41,6 +41,8 @@ if [[ "$OS_NAME" = "linux" ]]; then
 
 # Do a different test set-up than the autotools build
   OPTS_CMAKE="$OPTS_CMAKE -D CGNS_ENABLE_LEGACY:BOOL=ON -D CGNS_ENABLE_64BIT:BOOL=OFF"
+else
+  OPTS_CMAKE="$OPTS_CMAKE -D CMAKE_OSX_ARCHITECTURES:STRING='arm64;x86_64'"
 fi
 
 if [[ "$BUILD" == "cmake" ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,10 @@ jobs:
             "--${{ matrix.parallel }}-parallel --${{ matrix.fortran }}-fortran --${{ matrix.hdf5 }}-hdf5 --${{ matrix.tools }}-cgnstools"
       shell: bash
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: matrix.os == 'macos-latest'
+
 ##################################
 # TEST CGNS (CMAKE)
 ##################################

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,8 +119,8 @@ jobs:
     - name: CMake test CGNS
       run: |
         cd cbuild
-        make -j 8
-        make test
+        cmake --build . --config "Debug" --parallel 8
+        ctest -C "Debug" --verbose --output-on-failure
       shell: bash
 
 ##################################

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
             artifact: "macOS.tar.xz"
             os: macos-latest
             parallel: disable
-            fortran: with
+            fortran: without
             hdf5: without
             tools: disable
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
             artifact: "macOS.tar.xz"
             os: macos-latest
             parallel: disable
-            fortran: without
-            hdf5: without
+            fortran: with
+            hdf5: with
             tools: disable
 
     name: ${{ matrix.name }}
@@ -111,10 +111,6 @@ jobs:
         bash .github/workflows/config-cgns.sh cmake \
             "--${{ matrix.parallel }}-parallel --${{ matrix.fortran }}-fortran --${{ matrix.hdf5 }}-hdf5 --${{ matrix.tools }}-cgnstools"
       shell: bash
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: matrix.os == 'macos-latest'
 
 ##################################
 # TEST CGNS (CMAKE)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     strategy:
       matrix:
-        name: ["Ubuntu Latest GCC", "macOS Latest"]
+        name: ["Ubuntu Latest GCC", "macOS Latest Clang"]
         include:
           - name: "Ubuntu Latest GCC"
             artifact: "Linux.tar.xz"
@@ -29,7 +29,7 @@ jobs:
             parallel: enable
             hdf5: with
             tools: enable
-          - name: "macOS Latest"
+          - name: "macOS Latest Clang"
             artifact: "macOS.tar.xz"
             os: macos-latest
             parallel: disable
@@ -73,8 +73,9 @@ jobs:
         echo "FC=gfortran" >> $GITHUB_ENV
         echo "F77=gfortran" >> $GITHUB_ENV
         # Set CC version to latest gcc based on gfortran main version
-        gfortranversion=$( echo "__GNUC__" | gfortran -E -P - | sed 's/ //g' )
-        echo "CC=gcc-$gfortranversion" >> $GITHUB_ENV
+        #gfortranversion=$( echo "__GNUC__" | gfortran -E -P - | sed 's/ //g' )
+        #echo "CC=gcc-$gfortranversion" >> $GITHUB_ENV
+        echo "CC=gcc" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 #  push:
 #  pull_request:
 env:
-  hdf5_vers: 1_10_8
+  hdf5_vers: 1_10_10
 
 # A workflow run is made up of one or more jobs that
 # can run sequentially or in parallel
@@ -20,7 +20,7 @@ jobs:
   build:
     strategy:
       matrix:
-        name: ["Ubuntu Latest GCC", "macOS Latest Clang"]
+        name: ["Ubuntu Latest GCC", "macOS Latest"]
         include:
           - name: "Ubuntu Latest GCC"
             artifact: "Linux.tar.xz"
@@ -29,7 +29,7 @@ jobs:
             parallel: enable
             hdf5: with
             tools: enable
-          - name: "macOS Latest Clang"
+          - name: "macOS Latest"
             artifact: "macOS.tar.xz"
             os: macos-latest
             parallel: disable
@@ -64,14 +64,17 @@ jobs:
         unset HOMEBREW_NO_INSTALL_FROM_API
         unset HOMEBREW_NO_AUTO_UPDATE
         echo "OS_NAME=macOS" >> $GITHUB_ENV
-        echo "CC=gcc" >> $GITHUB_ENV
         # Use the newest stable gcc compiler
         brew update-reset
-        brew upgrade gcc
+        brew cleanup
+        #brew upgrade gcc
         brew install gcc
         brew unlink gcc && brew link gcc
         echo "FC=gfortran" >> $GITHUB_ENV
         echo "F77=gfortran" >> $GITHUB_ENV
+        # Set CC version to latest gcc based on gfortran main version
+        gfortranversion=$( echo "__GNUC__" | gfortran -E -P - | sed 's/ //g' )
+        echo "CC=gcc-$gfortranversion" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.20)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,10 +35,10 @@ environment:
   global:
     1_8: &1_8 1.8.23
     1_10: &1_10 1.10.10
-    1_12: &1_12 1.12.3
+    1_12: &1_14 1.14.3
     HDF5_1_8_VER: *1_8   
     HDF5_1_10_VER: *1_10
-    HDF5_1_12_VER: *1_12
+    HDF5_1_14_VER: *1_14
   matrix:
   - build_opt: -D CGNS_BUILD_SHARED:BOOL=OFF -D CGNS_USE_SHARED:BOOL=OFF -D CGNS_ENABLE_64BIT:BOOL=OFF
     HDF5_VER: *1_8
@@ -50,10 +50,10 @@ environment:
     HDF5_VER: *1_10
     HDF_DIR: "/Program Files/HDF_Group/HDF5/%HDF5_VER%/cmake"
   - build_opt: -D CGNS_BUILD_SHARED:BOOL=OFF -D CGNS_USE_SHARED:BOOL=OFF -D CGNS_ENABLE_64BIT:BOOL=ON
-    HDF5_VER: *1_12
+    HDF5_VER: *1_14
     HDF_DIR: "/Program Files/HDF_Group/HDF5/%HDF5_VER%/cmake"
   - build_opt: -D CGNS_BUILD_SHARED:BOOL=ON -D CGNS_USE_SHARED:BOOL=ON -D CGNS_ENABLE_64BIT:BOOL=ON
-    HDF5_VER: *1_12
+    HDF5_VER: *1_14
     HDF_DIR: "/Program Files/HDF_Group/HDF5/%HDF5_VER%/cmake"
 
 for:
@@ -119,13 +119,13 @@ install:
   - msiexec /i HDF5-%HDF5_1_10_VER%-win64.msi /quiet /qn /norestart /log install.log
   - type install.log
   - cd ..\..
-  - mkdir 1.12
-  - cd 1.12
-  - set HDF5_1_12=%HDF5_1_12_VER%
-  - curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.3/bin/windows/hdf5-%HDF5_1_12_VER%-Std-win10_64-%SHORTGEN%.zip
-  - ps: Expand-Archive hdf5-$($env:HDF5_1_12_VER)-Std-win10_64-$($env:SHORTGEN).zip -DestinationPath .
+  - mkdir 1.14
+  - cd 1.14
+  - set HDF5_1_14=%HDF5_1_14_VER%
+  - curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.3/bin/windows/hdf5-%HDF5_1_14_VER%-Std-win10_64-%SHORTGEN%.zip
+  - ps: Expand-Archive hdf5-$($env:HDF5_1_14_VER)-Std-win10_64-$($env:SHORTGEN).zip -DestinationPath .
   - cd hdf
-  - msiexec /i HDF5-%HDF5_1_12_VER%-win64.msi /quiet /qn /norestart /log install.log
+  - msiexec /i HDF5-%HDF5_1_14_VER%-win64.msi /quiet /qn /norestart /log install.log
   - type install.log
   - cd ..\..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@
 version: 4.5.{build}
 
 image:
-  - Visual Studio 2017
+  - Visual Studio 2022
   - Visual Studio 2019
   
 # branches to build
@@ -33,9 +33,9 @@ skip_tags: true
 #---------------------------------#
 environment:
   global:
-    1_8: &1_8 1.8.21
-    1_10: &1_10 1.10.6
-    1_12: &1_12 1.12.0
+    1_8: &1_8 1.8.23
+    1_10: &1_10 1.10.10
+    1_12: &1_12 1.12.3
     HDF5_1_8_VER: *1_8   
     HDF5_1_10_VER: *1_10
     HDF5_1_12_VER: *1_12
@@ -64,6 +64,7 @@ for:
   environment:
       GENERATOR: "Visual Studio 16 2019"
       ARCH: "x64"
+      SHORTGEN: "vs16"
 -
   matrix:
     only:
@@ -71,6 +72,15 @@ for:
   environment:
       GENERATOR: "Visual Studio 15 2017"
       ARCH: "x64"
+      SHORTGEN: "vs15"
+-
+  matrix:
+    only:
+      - image: Visual Studio 2022
+  environment:
+      GENERATOR: "Visual Studio 17 2022"
+      ARCH: "x64"
+      SHORTGEN: "vs17"
 
 # scripts that are called at very beginning, before repo cloning
 init:
@@ -94,8 +104,8 @@ install:
   - mkdir 1.8
   - cd 1.8
   - set HDF5_1_8_VER=%HDF5_1_8_VER%
-  - curl -O https://gamma.hdfgroup.org/ftp/pub/outgoing/QATEST/hdf518/relbinaries/windows/hdf5-%HDF5_1_8_VER%-Std-win10_64-vs16.zip
-  - ps: Expand-Archive hdf5-$($env:HDF5_1_8_VER)-Std-win10_64-vs16.zip -DestinationPath .
+  - curl -O https://gamma.hdfgroup.org/ftp/pub/outgoing/QATEST/hdf518/relbinaries/windows/hdf5-%HDF5_1_8_VER%-Std-win10_64-%SHORTGEN%.zip
+  - ps: Expand-Archive hdf5-$($env:HDF5_1_8_VER)-Std-win10_64-$($env:SHORTGEN).zip -DestinationPath .
   - cd hdf
   - msiexec /i HDF5-%HDF5_1_8_VER%-win64.msi /quiet /qn /norestart /log install.log
   - type install.log
@@ -103,8 +113,8 @@ install:
   - mkdir 1.10
   - cd 1.10
   - set HDF5_1_10=%HDF5_1_10_VER%
-  - curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/bin/hdf5-%HDF5_1_10_VER%-Std-win10_64-vs16.zip
-  - ps: Expand-Archive hdf5-$($env:HDF5_1_10_VER)-Std-win10_64-vs16.zip -DestinationPath .
+  - curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.10/bin/windows/hdf5-%HDF5_1_10_VER%-Std-win10_64-%SHORTGEN%.zip
+  - ps: Expand-Archive hdf5-$($env:HDF5_1_10_VER)-Std-win10_64-$($env:SHORTGEN).zip -DestinationPath .
   - cd hdf
   - msiexec /i HDF5-%HDF5_1_10_VER%-win64.msi /quiet /qn /norestart /log install.log
   - type install.log
@@ -112,8 +122,8 @@ install:
   - mkdir 1.12
   - cd 1.12
   - set HDF5_1_12=%HDF5_1_12_VER%
-  - curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/bin/hdf5-%HDF5_1_12_VER%-Std-win10_64-vs16.zip
-  - ps: Expand-Archive hdf5-$($env:HDF5_1_12_VER)-Std-win10_64-vs16.zip -DestinationPath .
+  - curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.3/bin/windows/hdf5-%HDF5_1_12_VER%-Std-win10_64-%SHORTGEN%.zip
+  - ps: Expand-Archive hdf5-$($env:HDF5_1_12_VER)-Std-win10_64-$($env:SHORTGEN).zip -DestinationPath .
   - cd hdf
   - msiexec /i HDF5-%HDF5_1_12_VER%-win64.msi /quiet /qn /norestart /log install.log
   - type install.log

--- a/src/fortran_macros.h
+++ b/src/fortran_macros.h
@@ -136,9 +136,21 @@ freely, subject to the following restrictions:
 
 #endif
 
+/* For modern GCC or ARM64 config, assume size_t for string length */
+
 #ifndef STR_PSTR
 #	define STR_PSTR(str)       char *str
-#	define STR_PLEN(str)       , int CONCATENATE(Len,str)
+#if defined(__arm64__) && defined(__APPLE__)
+#	define STR_PLEN(str)       , size_t  CONCATENATE(Len,str)
+#elif defined(__GNUC__)
+#if __GNUC__ > 7
+#	define STR_PLEN(str)       , size_t  CONCATENATE(Len,str)
+#else
+#	define STR_PLEN(str)       , int  CONCATENATE(Len,str)
+#endif
+#else
+#	define STR_PLEN(str)       , int  CONCATENATE(Len,str)
+#endif
 #	define STR_PTR(str)        str
 #	define STR_LEN(str)        CONCATENATE(Len,str)
 #endif

--- a/src/tests/test_general_reshape.c
+++ b/src/tests/test_general_reshape.c
@@ -256,7 +256,8 @@ int main (int argc, char *argv[])
                               3, m_dims, m_rmin, m_rmax, ibuf_1d))
         cg_error_exit();
     for (i = 0; i < dims_1d(0); i++) {
-        if (ibuf_1d[i] != (int)fvalues_1d[i]) ++np;
+        int tmp_cmp = (int)round(fvalues_1d[i]);
+        if (ibuf_1d[i] != tmp_cmp) ++np;
     }
     nn += np;
     if (np) printf("%d differences in values (T2)\n", np);
@@ -463,7 +464,8 @@ int main (int argc, char *argv[])
                               1, m_dims, m_rmin, m_rmax, ibuf_1d))
       cg_error_exit();
     for (i = 0; i < dims_1d(0); i++) {
-        if (ibuf_1d[i] != (int)fvalues_1d[i]) ++np;
+        int tmp_cmp = (int)round(fvalues_1d[i]);
+        if (ibuf_1d[i] != tmp_cmp) ++np;
     }
     /* read the second in 3d */
     for (n=0; n<3; n++) {
@@ -482,7 +484,8 @@ int main (int argc, char *argv[])
                               3, m_dims, m_rmin, m_rmax, ibuf_1d))
       cg_error_exit();
     for (i = 0; i < dims_1d(0); i++) {
-        if (ibuf_1d[i] != (int)dvalues_1d[i]) ++np;
+        int tmp_cmp = (int)lround(dvalues_1d[i]);
+        if (ibuf_1d[i] != tmp_cmp) ++np;
     }
     nn += np;
     if (np) printf("%d differences in values (T5)\n", np);


### PR DESCRIPTION
- Update cmake requirement to be coherent with hdf5.
  This could also help with packaging on the long run.

- Fix Fortran to C mapping on Apple ARM64
 This is compiler dependent so a better design based on ISO C should be possible.
 The current correction is based on https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gfortran.pdf  (see hidden parameter section)