### PR TITLE
[cgnscheck] check multiple gridcoordinates nodes & nullpointer

### DIFF
--- a/src/tools/cgnscheck.c
+++ b/src/tools/cgnscheck.c
@@ -2561,8 +2561,8 @@ static void check_coordinates (int ng)
 {
     char name[33];
     int ierr, n, rind[6];
-    cgsize_t np, rmin[3], rmax[3];
-    int nc, ncoords, mask, coordset[4];
+    cgsize_t np, dimensions, rmin[3], rmax[3];
+    int nc, ncoords, mask, rank, coordset[4];
     int *punits, units[9], dataclass;
     float *coord, cmin, cmax;
     CGNS_ENUMT(DataType_t) datatype;
@@ -2625,19 +2625,20 @@ static void check_coordinates (int ng)
         fatal_error("malloc failed for %" PRIdCGSIZE " coordinate values\n", np);
     if (z->maxnode < np) z->maxnode = np;
 
-    if (cg_ncoords (cgnsfn, cgnsbase, cgnszone, &ncoords))
-        error_exit("cg_ncoords");
+    go_absolute ("Zone_t", cgnszone, "GridCoordinates_t", ng, NULL);
+
+    if (cg_narrays (&ncoords))
+        error_exit("cg_narrays");
     if (ncoords < PhyDim)
         error ("number coordinates < physical dimensions");
     for (n = 0; n < 4; n++)
         coordset[n] = 0;
 
     for (nc = 1; nc <= ncoords; nc++) {
-        if (cg_coord_info (cgnsfn, cgnsbase, cgnszone, nc, &datatype, name))
-            error_exit("cg_coord_info");
-        if (cg_coord_read (cgnsfn, cgnsbase, cgnszone, name, CGNS_ENUMV(RealSingle),
-                rmin, rmax, coord))
-            error_exit("cg_coord_read");
+        if (cg_array_info (nc, name, &datatype, &rank, &dimensions))
+            error_exit("cg_array_info");
+        if (cg_array_read_as (nc, CGNS_ENUMV(RealSingle), coord))
+            error_exit("cg_array_read");
         printf ("    checking coordinate \"%s\"\n", name);
         fflush (stdout);
         cmin = cmax = coord[0];
@@ -5168,7 +5169,7 @@ static void check_zone_iter (void)
                         for (nn = 0; nn < NumArbitraryGrid; nn++) {
                             if (0 == strcmp (buff, ArbitraryGrid[nn])) break;
                         }
-                        if (nn == NumArbitraryGrid) ierr++;
+                        if ((nn == NumArbitraryGrid) && (0 != strcmp (buff, "Null"))) ierr++;
                     }
                 }
                 else if (0 == strcmp (name, "FlowSolutionPointers")) {
@@ -5182,7 +5183,7 @@ static void check_zone_iter (void)
                         for (nn = 0; nn < NumFlowSolution; nn++) {
                             if (0 == strcmp (buff, FlowSolution[nn])) break;
                         }
-                        if (nn == NumFlowSolution) ierr++;
+                        if ((nn == NumFlowSolution) && (0 != strcmp (buff, "Null"))) ierr++;
                     }
                 }
                 else if (0 == strcmp (name, "GridCoordinatesPointers")) {
@@ -5196,7 +5197,7 @@ static void check_zone_iter (void)
                         for (nn = 0; nn < NumGridCoordinate; nn++) {
                             if (0 == strcmp (buff, GridCoordinate[nn])) break;
                         }
-                        if (nn == NumGridCoordinate) ierr++;
+                        if ((nn == NumGridCoordinate) && (0 != strcmp (buff, "Null"))) ierr++;
                     }
                 }
                 else if (0 == strcmp (name, "RigidGridMotionPointers")) {
@@ -5210,7 +5211,7 @@ static void check_zone_iter (void)
                         for (nn = 0; nn < NumRigidGrid; nn++) {
                             if (0 == strcmp (buff, RigidGrid[nn])) break;
                         }
-                        if (nn == NumRigidGrid) ierr++;
+                        if ((nn == NumRigidGrid) && (0 != strcmp (buff, "Null"))) ierr++;
                     }
                 }
                 else if (0 == strcmp (name, "ZoneGridConnectivityPointers")) {
@@ -5224,7 +5225,7 @@ static void check_zone_iter (void)
                         for (nn = 0; nn < NumZoneConn; nn++) {
                             if (0 == strcmp (buff, ZoneConn[nn])) break;
                         }
-                        if (nn == NumZoneConn) ierr++;
+                        if ((nn == NumZoneConn) && (0 != strcmp (buff, "Null"))) ierr++;
                     }
                 }
                 else {
@@ -5238,7 +5239,7 @@ static void check_zone_iter (void)
                         for (nn = 0; nn < NumZoneSubReg; nn++) {
                             if (0 == strcmp (buff, ZoneSubReg[nn])) break;
                         }
-                        if (nn == NumZoneSubReg) ierr++;
+                        if ((nn == NumZoneSubReg) && (0 != strcmp (buff, "Null"))) ierr++;
                     }
                 }
                 free (desc);


### PR DESCRIPTION
Hi,

this branch includes improvements of cgnscheck:
- check all GridCoordinates_t nodes
- allow "Null" keywords for *Pointers