### PR TITLE
Fixed cgsize_t type for MPI calls in test

### DIFF
--- a/src/ptests/Makefile.in
+++ b/src/ptests/Makefile.in
@@ -28,7 +28,13 @@ CALL =	pcgns_ctest$(EXE) \
 	test_poly_unstructured$(EXE) \
 	thesis_benchmark$(EXE)
 
-FALL =	pcgns_ftest$(EXE) ftest_zone$(EXE) fexample$(EXE) benchmark_hdf5_f90$(EXE) test_mixed_par_ser$(EXE) test_unstruc_quad_f90$(EXE)
+FALL =	pcgns_ftest$(EXE) \
+	ftest_zone$(EXE) \
+	fexample$(EXE) \
+	benchmark_hdf5_f90$(EXE) \
+	test_mixed_par_ser$(EXE) \
+	test_unstruc_quad_f90$(EXE) \
+	test_poly_unstructured_f90$(EXE)
 
 ALL   = $(CALL) @FALL@
 TESTS = $(ALL)

--- a/src/ptests/test_poly_unstructured.c
+++ b/src/ptests/test_poly_unstructured.c
@@ -28,6 +28,7 @@
 
 #include "mpi.h"
 #include "pcgnslib.h"
+#include "cgnstypes.h"
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
@@ -172,8 +173,13 @@ int main(int argc, char **argv) {
   offsets_sizes = (long *)malloc(sizeof(long) * comm_size);
   local_size = offsets[cellOnProcEnd - cellOnProcStart];
 
-  MPI_Allgather(&local_size, 1, MPI_LONG, offsets_sizes, 1, MPI_LONG,
+#if CG_BUILD_64BIT
+  MPI_Allgather(&local_size, 1, MPI_INT64_T, offsets_sizes, 1, MPI_INT64_T,
                 comm_parallel);
+#else
+  MPI_Allgather(&local_size, 1, MPI_INT32_T, offsets_sizes, 1, MPI_INT32_T,
+                comm_parallel);
+#endif
 
   for (int iProc = 0; iProc < comm_size; iProc++) {
     if (iProc < comm_rank) {

--- a/src/ptests/test_poly_unstructured_f90.F90
+++ b/src/ptests/test_poly_unstructured_f90.F90
@@ -154,8 +154,13 @@ PROGRAM test_poly_unstructured_f
   ALLOCATE(offsets_sizes(comm_size))
   local_size(1) = offsets(nbCellWrite+1)
 
-  CALL MPI_Allgather(local_size, 1, MPI_LONG, offsets_sizes, 1, MPI_LONG, &
+#if CG_BUILD_64BIT_F
+  CALL MPI_Allgather(local_size, 1, MPI_LONG_LONG, offsets_sizes, 1, MPI_LONG_LONG, &
                       MPI_COMM_WORLD, ierr)
+#else
+  CALL MPI_Allgather(local_size, 1, MPI_INTEGER, offsets_sizes, 1, MPI_INTEGER, &
+                      MPI_COMM_WORLD, ierr)
+#endif
 
   DO iProc = 1, comm_size
     IF (iProc-1 < comm_rank) THEN

--- a/src/ptests/test_poly_unstructured_f90.F90
+++ b/src/ptests/test_poly_unstructured_f90.F90
@@ -155,10 +155,10 @@ PROGRAM test_poly_unstructured_f
   local_size(1) = offsets(nbCellWrite+1)
 
 #if CG_BUILD_64BIT_F
-  CALL MPI_Allgather(local_size, 1, MPI_LONG_LONG, offsets_sizes, 1, MPI_LONG_LONG, &
+  CALL MPI_Allgather(local_size, 1, MPI_INT64_T, offsets_sizes, 1, MPI_INT64_T, &
                       MPI_COMM_WORLD, ierr)
 #else
-  CALL MPI_Allgather(local_size, 1, MPI_INTEGER, offsets_sizes, 1, MPI_INTEGER, &
+  CALL MPI_Allgather(local_size, 1, MPI_INT32_T, offsets_sizes, 1, MPI_INT32_T, &
                       MPI_COMM_WORLD, ierr)
 #endif
 


### PR DESCRIPTION
Fixed assumption that cgsize_t is always integer*8 in test, added missing test for autotools.