### PR TITLE
Misc windows fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,15 +83,24 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Sun")
   check_and_add_compiler_option("-xc99")
 endif()
 
-string(COMPARE EQUAL ${CMAKE_BUILD_TYPE} Debug IS_DEBUG)
-if (IS_DEBUG)
-  set(BUILDDEBUG 1)
-  set(CFLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}")
-  set(LDFLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
+if (NOT DEFINED CMAKE_CONFIGURATION_TYPES)
+  # Buggy section used for generating buildConfig.def
+  # A CMake generator with conditional could be used
+  # as using CMAKE_BUILD_TYPE is not good practise
+  string(COMPARE EQUAL ${CMAKE_BUILD_TYPE} Debug IS_DEBUG)
+  if (IS_DEBUG)
+    set(BUILDDEBUG 1)
+    set(CFLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}")
+    set(LDFLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
+  else ()
+    set(BUILDDEBUG 0)
+    set(CFLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}")
+    set(LDFLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+  endif ()
 else ()
   set(BUILDDEBUG 0)
-  set(CFLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}")
-  set(LDFLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+  set(CFLAGS "")
+  set(LDFLAGS "")
 endif ()
 
 set(BUILDHDF5 0)
@@ -529,10 +538,11 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/cgnstypes_f03.h.in
 		${CMAKE_CURRENT_BINARY_DIR}/cgnstypes_f03.h )
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/cgnsconfig.h.in
 		${CMAKE_CURRENT_BINARY_DIR}/cgnsconfig.h )
-configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/cgnsBuild.defs.in
-		${CMAKE_CURRENT_BINARY_DIR}/cgnsBuild.defs )
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/cg_hash_types.h.in
 		${CMAKE_CURRENT_BINARY_DIR}/cg_hash_types.h )
+# The following is only useful with Unix Makefile Generator
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/cgnsBuild.defs.in
+		${CMAKE_CURRENT_BINARY_DIR}/cgnsBuild.defs )
 
 ###########
 # Library #

--- a/src/cgns_header.h
+++ b/src/cgns_header.h
@@ -956,13 +956,6 @@ typedef struct {
     double id;
 } cgns_posit;
 
-/* need some of these routines exported for CGNStools */
-
-#if defined(_WIN32) && defined(BUILD_DLL)
-# define CGNSDLL __declspec(dllexport)
-#else
-# define CGNSDLL
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -172,6 +172,11 @@ if (CGNS_ENABLE_TESTS)
     endif()
     add_test(NAME ${TARGETNAME} COMMAND ${TARGETNAME})
     set_property (TEST ${TARGETNAME} PROPERTY SKIP_RETURN_CODE 125)
+    # On windows help ctest to find the required dlls
+    if(CGNS_BUILD_SHARED)
+      set_tests_properties(${TARGETNAME} PROPERTIES ENVIRONMENT_MODIFICATION
+        "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:${TARGETNAME}>,\;>>")
+    endif()
 
   endforeach()
 
@@ -179,6 +184,11 @@ if (CGNS_ENABLE_TESTS)
   if (CGNS_ENABLE_FORTRAN)
     foreach(TARGETNAME ${FORTRAN_TESTS_LIST})
       add_test(NAME ${TARGETNAME} COMMAND ${TARGETNAME})
+      # On windows help ctest to find the required dlls
+      if(CGNS_BUILD_SHARED)
+        set_tests_properties(${TARGETNAME} PROPERTIES ENVIRONMENT_MODIFICATION
+          "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:${TARGETNAME}>,\;>>")
+      endif()
     endforeach()
   endif (CGNS_ENABLE_FORTRAN)
 endif (CGNS_ENABLE_TESTS)


### PR DESCRIPTION
Some small fixes:
- be more robust to multiconfiguration cmake generators
- fix ctest path on windows
- remove redefinition of a macro