### PR TITLE
Fix CGNS-779 

### DIFF
--- a/src/cgns_header.h
+++ b/src/cgns_header.h
@@ -1248,7 +1248,7 @@ int cgi_zone_no(cgns_base *base, char *zonename, int *zone_no);
 
 /* miscellaneous */
 int cgi_sort_names(int n, double *ids);
-int size_of(const char_33 adf_type);
+size_t size_of(const char_33 adf_type);
 char *type_of(char_33 data_type);
 int cgi_check_strlen(char const * string);
 int cgi_check_strlen_x2(char const *string);

--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -6912,7 +6912,7 @@ int cgi_read_offset_data_type(double id, char const *data_type, cgsize_t start, 
     else {
         if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2) {
             void* conv_data = NULL;
-            conv_data = malloc((size_t)(cnt * size_of(data_type)));
+            conv_data = malloc(((size_t)cnt) * size_of(data_type));
             if (conv_data == NULL) {
                 cgi_error("Error allocating conv_data");
                 return CG_ERROR;
@@ -9578,7 +9578,7 @@ int cgi_array_general_read(
             return CG_ERROR;
         }
         void *conv_data;
-        conv_data = malloc((size_t)(numpt*size_of(array->data_type)));
+        conv_data = malloc(((size_t)numpt)*size_of(array->data_type));
         if (conv_data == NULL) {
             cgi_error("Error allocating conv_data");
             return CG_ERROR;
@@ -9768,7 +9768,7 @@ int cgi_array_general_write(
             return CG_ERROR;
         }
         void *conv_data;
-        conv_data = malloc((size_t)(numpt*size_of(array->data_type)));
+        conv_data = malloc(((size_t)numpt)*size_of(array->data_type));
         if (conv_data == NULL) {
             cgi_error("Error allocating conv_data");
             return CG_ERROR;
@@ -9928,7 +9928,7 @@ char *type_of(char_33 data_type)
     }
 }
 
-int size_of(const char_33 data_type)
+size_t size_of(const char_33 data_type)
 {
     if (strcmp(data_type, "I4") == 0) return sizeof(int);
     if (strcmp(data_type, "I8") == 0) return sizeof(cglong_t);

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -5848,7 +5848,7 @@ int cg_elements_general_read(int fn, int B, int Z, int S,
     }
     else if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2) {
         void* conv_data = NULL;
-        conv_data = malloc((size_t)(size * size_of(cgi_adf_datatype(s_type))));
+        conv_data = malloc(((size_t)size) * size_of(cgi_adf_datatype(s_type)));
         if (conv_data == NULL) {
             cgi_error("Error allocating conv_data");
             return CG_ERROR;
@@ -5992,7 +5992,7 @@ int cg_parent_elements_general_read(int fn, int B, int Z, int S,
     }
     else if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2) {
         void* conv_data = NULL;
-        conv_data = malloc((size_t)(m_dim[0] * 2 * size_of(cgi_adf_datatype(s_type))));
+        conv_data = malloc(((size_t)(m_dim[0] * 2)) * size_of(cgi_adf_datatype(s_type)));
         if (conv_data == NULL) {
             cgi_error("Error allocating conv_data");
             return CG_ERROR;
@@ -6138,7 +6138,7 @@ int cg_parent_elements_position_general_read(int fn, int B, int Z, int S,
     }
     else if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2) {
         void* conv_data = NULL;
-        conv_data = malloc((size_t)(m_dim[0] * 2 * size_of(cgi_adf_datatype(s_type))));
+        conv_data = malloc(((size_t)(m_dim[0] * 2)) * size_of(cgi_adf_datatype(s_type)));
         if (conv_data == NULL) {
             cgi_error("Error allocating conv_data");
             return CG_ERROR;
@@ -6513,7 +6513,7 @@ int cg_poly_elements_general_read(int fn, int B, int Z, int S,
     }
     else if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2) {
         void* conv_data = NULL;
-        conv_data = malloc((size_t)(size * size_of(cgi_adf_datatype(s_type))));
+        conv_data = malloc(((size_t)size) * size_of(cgi_adf_datatype(s_type)));
         if (conv_data == NULL) {
             cgi_error("Error allocating conv_data");
             return CG_ERROR;
@@ -6585,8 +6585,8 @@ int cg_elements_partial_write(int fn, int B, int Z, int S,
     } \
     else if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2){ \
     void *conv_data=NULL; \
-    conv_data = malloc((size_t)((m_end-m_start+1) \
-    *size_of(ARRAY->data_type))); \
+    conv_data = malloc(((size_t)(m_end-m_start+1)) \
+    *size_of(ARRAY->data_type)); \
     if (conv_data == NULL) { \
     cgi_error("Error allocating conv_data"); \
     STATUS = CG_ERROR; \
@@ -6625,8 +6625,8 @@ int cg_elements_partial_write(int fn, int B, int Z, int S,
     } \
     else if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2){ \
     void *conv_data; \
-    conv_data = malloc((size_t)((m_end[0]-m_start[0]+1)*(m_end[1]-m_start[1]+1) \
-    *size_of(ARRAY->data_type))); \
+    conv_data = malloc((size_t)((m_end[0]-m_start[0]+1)*(m_end[1]-m_start[1]+1)) \
+    *size_of(ARRAY->data_type)); \
     if (conv_data == NULL) { \
     cgi_error("Error allocating conv_data"); \
     return CG_ERROR; \
@@ -6667,8 +6667,8 @@ int cg_elements_partial_write(int fn, int B, int Z, int S,
     void *conv_data; \
     cgsize_t conv_size=1; \
     for (int ii=0; ii<S_DIM; ii++){ conv_size *= ARRAY->dim_vals[ii]; } \
-    conv_data = malloc((size_t)(conv_size \
-    *size_of(ARRAY->data_type))); \
+    conv_data = malloc(((size_t)conv_size) \
+    *size_of(ARRAY->data_type)); \
     if (conv_data == NULL) { \
     cgi_error("Error allocating conv_data"); \
     return CG_ERROR; \
@@ -6705,7 +6705,7 @@ int cg_elements_partial_write(int fn, int B, int Z, int S,
     } \
     } else if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2) { \
     void *conv_data = NULL; \
-    conv_data = malloc((size_t)(SIZE*size_of(cgi_adf_datatype(S_TYPE)))); \
+    conv_data = malloc(((size_t)SIZE)*size_of(cgi_adf_datatype(S_TYPE))); \
     if (conv_data==NULL){ \
     cgi_error("Error allocating conv_data"); \
     STATUS = CG_ERROR; \
@@ -7286,7 +7286,7 @@ int cg_poly_elements_general_write(int fn, int B, int Z, int S,
                     }
                 } else if (cg->filetype == CGIO_FILE_ADF || cg->filetype == CGIO_FILE_ADF2) {
                     void *conv_data = NULL;
-                    conv_data = malloc((size_t)(m_trail_size*size_of(section->connect->data_type)));
+                    conv_data = malloc(((size_t)m_trail_size)*size_of(section->connect->data_type));
                     if (conv_data == NULL) {
                         cgi_error("Error allocating conv_data");
                         ier = CG_ERROR;
@@ -11004,7 +11004,7 @@ int cg_boco_read(int fn, int B, int Z, int BC, cgsize_t *pnts, void *NormalList)
     dim = cg->base[B-1].phys_dim;
     if (NormalList && boco->normal && boco->ptset && boco->ptset->npts>0) {
         memcpy(NormalList, boco->normal->data,
-        (size_t)(boco->ptset->size_of_patch*dim*size_of(boco->normal->data_type)));
+        ((size_t)(boco->ptset->size_of_patch*dim))*size_of(boco->normal->data_type));
     }
 
     return CG_OK;
@@ -11382,12 +11382,12 @@ int cg_boco_normal_write(int fn, int B, int Z, int BC, const int * NormalIndex,
         normal = boco->normal;
 
         strcpy(normal->data_type, cgi_adf_datatype(NormalDataType));
-        normal->data = (void *)malloc((size_t)(npnts*phys_dim*size_of(normal->data_type)));
+        normal->data = (void *)malloc(((size_t)(npnts*phys_dim))*size_of(normal->data_type));
         if (normal->data == NULL) {
             cgi_error("Error allocating normal->data");
             return CG_ERROR;
         }
-        memcpy(normal->data, NormalList, (size_t)(npnts*phys_dim*size_of(normal->data_type)));
+        memcpy(normal->data, NormalList, ((size_t)(npnts*phys_dim))*size_of(normal->data_type));
         strcpy(normal->name, "InwardNormalList");
         normal->data_dim =2;
         normal->dim_vals[0]=phys_dim;
@@ -15204,7 +15204,7 @@ int cg_array_read(int A, void *Data)
     for (n=0; n<array->data_dim; n++) num *= array->dim_vals[n];
 
     if (array->data)
-        memcpy(Data, array->data, (size_t)(num*size_of(array->data_type)));
+        memcpy(Data, array->data, ((size_t)num)*size_of(array->data_type));
     else {
         if (cgio_read_all_data_type(cg->cgio, array->id, array->data_type, Data)) {
             cg_io_error("cgio_read_all_data_type");
@@ -15256,7 +15256,7 @@ int cg_array_read_as(int A, CGNS_ENUMT(DataType_t) type, void *Data)
     }
     if (type==CGNS_ENUMV(Character)) {
         if (array->data)
-            memcpy(Data, array->data, (size_t)(num*size_of(array->data_type)));
+            memcpy(Data, array->data, ((size_t)num)*size_of(array->data_type));
         else {
             if (cgio_read_all_data_type(cg->cgio, array->id, array->data_type, Data)) {
                 cg_io_error("cgio_read_all_data_type");
@@ -15270,7 +15270,7 @@ int cg_array_read_as(int A, CGNS_ENUMT(DataType_t) type, void *Data)
     if (array->data)
         array_data = array->data;
     else {
-        array_data = malloc((size_t)(num*size_of(array->data_type)));
+        array_data = malloc(((size_t)num)*size_of(array->data_type));
         if (array_data == NULL) {
             cgi_error("Error allocating array_data");
             return CG_ERROR;

--- a/src/tools/cgnscheck.c
+++ b/src/tools/cgnscheck.c
@@ -1262,12 +1262,12 @@ static void read_zone (int nz)
         if (cg_ElementDataSize (cgnsfn, cgnsbase, nz, ns, &se))
             error_exit ("cg_ElementDataSize");
         if (se == 0) continue;
-        es->elements = (cgsize_t *) malloc ((size_t)(se * sizeof(cgsize_t)));
+        es->elements = (cgsize_t *) malloc (((size_t)se) * sizeof(cgsize_t));
         if (NULL == es->elements)
             fatal_error("malloc failed for elements\n");
         es->parent = NULL;
         if (hasparent) {
-            es->parent = (cgsize_t *) malloc ((size_t)(4 * nelem * sizeof(cgsize_t)));
+            es->parent = (cgsize_t *) malloc (((size_t)(4 * nelem)) * sizeof(cgsize_t));
             if (NULL == es->parent)
                 fatal_error("malloc failed for elemset parent data\n");
         }
@@ -1275,7 +1275,7 @@ static void read_zone (int nz)
         if (es->type == CGNS_ENUMV(MIXED) ||
             es->type == CGNS_ENUMV(NFACE_n) ||
             es->type == CGNS_ENUMV(NGON_n)) {
-            es->offsets = (cgsize_t *) malloc ((size_t)((nelem+1) * sizeof(cgsize_t)));
+            es->offsets = (cgsize_t *) malloc (((size_t)(nelem+1)) * sizeof(cgsize_t));
             if (NULL == es->offsets)
                 fatal_error("malloc failed for offsets\n");
             if (cg_poly_elements_read (cgnsfn, cgnsbase, nz, ns, es->elements, es->offsets,
@@ -1467,7 +1467,7 @@ static void read_zone (int nz)
                 if (tmp < idx_min) idx_min = tmp;
             }
             arr_size = idx_max - idx_min + 1;
-            face_tags = (unsigned char *) malloc((size_t)(arr_size *sizeof(unsigned char)));
+            face_tags = (unsigned char *) malloc(((size_t)arr_size) *sizeof(unsigned char));
             if (face_tags == NULL) {
                 fatal_error("malloc failed for face tags\n");
 	    }
@@ -1640,7 +1640,7 @@ static void read_zone (int nz)
         if (nodes[k]) ne++;
     }
     z->nextnodes = ne;
-    z->extnodes = (cgsize_t *) malloc ((size_t)(ne * sizeof(cgsize_t)));
+    z->extnodes = (cgsize_t *) malloc (((size_t)ne) * sizeof(cgsize_t));
     if (z->extnodes == NULL)
         fatal_error("malloc failed for zone exterior nodes\n");
     for (ne = 0, k = 0; k < maxnode; k++) {
@@ -2621,7 +2621,7 @@ static void check_coordinates (int ng)
         rmax[n] = z->dims[0][n] + rind[2*n] + rind[2*n+1];
         np *= rmax[n];
     }
-    if (NULL == (coord = (float *) malloc ((size_t)(np * sizeof(float)))))
+    if (NULL == (coord = (float *) malloc (((size_t)np) * sizeof(float))))
         fatal_error("malloc failed for %" PRIdCGSIZE " coordinate values\n", np);
     if (z->maxnode < np) z->maxnode = np;
 
@@ -3053,7 +3053,7 @@ static cgsize_t check_interface (ZONE *z, CGNS_ENUMT(PointSetType_t) ptype,
             }
             np *= (pmax[n] - pmin[n] + 1);
         }
-        p = (cgsize_t *) malloc ((size_t)(np * z->idim * sizeof(cgsize_t)));
+        p = (cgsize_t *) malloc (((size_t)(np * z->idim)) * sizeof(cgsize_t));
         if (p == NULL)
             fatal_error("malloc failed for point/element list\n");
         n = 0;
@@ -3277,7 +3277,7 @@ static void check_BCdata (CGNS_ENUMT(BCType_t) bctype, int dirichlet, int neuman
             size = 0;
         }
         else {
-            pts = (cgsize_t *) malloc ((size_t)(z->idim * npnts * sizeof(cgsize_t)));
+            pts = (cgsize_t *) malloc (((size_t)(z->idim * npnts)) * sizeof(cgsize_t));
             if (NULL == pts)
                 fatal_error("malloc failed for BCDataSet points\n");
             if (cg_ptset_read (pts)) error_exit("cg_ptset_read");
@@ -3439,7 +3439,7 @@ static void check_BC (int nb, int parclass, int *parunits)
         }
     }
 
-    pts = (cgsize_t *) malloc ((size_t)(z->idim * npts * sizeof(cgsize_t)));
+    pts = (cgsize_t *) malloc (((size_t)(z->idim * npts)) * sizeof(cgsize_t));
     if (NULL == pts)
         fatal_error("malloc failed for BC points\n");
     nrmllist = NULL;
@@ -4087,14 +4087,14 @@ static void check_conn (int nzc, int nc)
     check_user_data (z->dataclass, z->punits, 4);
 
     if (npts && dnpts) {
-        pts = (cgsize_t *) malloc ((size_t)(npts * z->idim * sizeof(cgsize_t)));
+        pts = (cgsize_t *) malloc (((size_t)(npts * z->idim)) * sizeof(cgsize_t));
         if (LibraryVersion < 2200) {
             /* a bug in version prior to 2.2 causes the base cell dimension */
             /* to be used here, instead of the donor zone index dimension */
-            dpts = (cgsize_t *) malloc ((size_t)(dnpts * CellDim * sizeof(cgsize_t)));
+            dpts = (cgsize_t *) malloc (((size_t)(dnpts * CellDim)) * sizeof(cgsize_t));
         }
         else
-            dpts = (cgsize_t *) malloc ((size_t)(dnpts * dz->idim * sizeof(cgsize_t)));
+            dpts = (cgsize_t *) malloc (((size_t)(dnpts * dz->idim)) * sizeof(cgsize_t));
         if (NULL == pts || NULL == dpts)
             fatal_error("malloc failed for connectivity points\n");
         if (cg_conn_read (cgnsfn, cgnsbase, cgnszone, nc, pts,
@@ -4256,7 +4256,7 @@ static void check_hole (int nzc, int nh)
     }
 
     if (!ierr && np > 0) {
-        cgsize_t *pnts = (cgsize_t *) malloc ((size_t)(np * z->idim * sizeof(cgsize_t)));
+        cgsize_t *pnts = (cgsize_t *) malloc (((size_t)(np * z->idim)) * sizeof(cgsize_t));
         if (pnts == NULL)
             fatal_error("malloc failed for hole data\n");
         if (cg_hole_read (cgnsfn, cgnsbase, cgnszone, nh, pnts))
@@ -5010,7 +5010,7 @@ static void check_subreg (int ns)
             }
         }
         if (!ierr) {
-            cgsize_t *pnts = (cgsize_t *)malloc(npnts * z->idim * sizeof(cgsize_t));
+            cgsize_t *pnts = (cgsize_t *)malloc(((size_t)(npnts * z->idim)) * sizeof(cgsize_t));
             if (pnts == NULL)
                 fatal_error("check_subreg:malloc failed for points\n");
             if (cg_subreg_ptset_read(cgnsfn, cgnsbase, cgnszone, ns, pnts))


### PR DESCRIPTION
- the cast to size_t is done before multiplying with size_of
- size_of now returns a size_t
- This prevent reduction of capacity in 32bit mode when cgsize_t is an int.

Fixing #779 