### PR TITLE
added #define _POSIX_SOURCE for POSIX specific functions (access and…

### DIFF
--- a/src/adf/ADF_interface.c
+++ b/src/adf/ADF_interface.c
@@ -96,6 +96,9 @@ static char ADF_A_identification[] = "\300\250\243\251ADF Database Version A0201
 /***********************************************************************
     Includes
 ***********************************************************************/
+#ifndef _WIN32
+  #define _POSIX_SOURCE
+#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/src/adf/ADF_internals.c
+++ b/src/adf/ADF_internals.c
@@ -166,6 +166,9 @@ bytes   start   end   description      range / format
 /***********************************************************************
  	Includes
 ***********************************************************************/
+#ifndef _WIN32
+  #define _POSIX_SOURCE
+#endif
 #include <sys/types.h>
 #include <time.h>
 #include <stdio.h>

--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -21,7 +21,9 @@ freely, subject to the following restrictions:
 /*-------------------------------------------------------------------
  * HDF5 interface to ADF
  *-------------------------------------------------------------------*/
-
+#ifndef _WIN32
+  #define _POSIX_SOURCE
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <math.h>

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -23,6 +23,9 @@ freely, subject to the following restrictions:
 #define _XOPEN_SOURCE 600
 #endif
 #endif
+#ifndef _WIN32
+  #define _POSIX_SOURCE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -104,7 +104,9 @@ freely, subject to the following restrictions:
  * \defgroup ParticleModel Particle Model
  *
  */
-
+#ifndef _WIN32
+  #define _POSIX_SOURCE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Added `#define _POSIX_SOURCE`  for POSIX-specific functions (`access` and `FILENO`) on POSIX-compliant OSs.

Fix for #810.