### PR TITLE
find_package(ZLIB) for compatibility with more recent hdf5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,6 @@ if (CGNS_ENABLE_HDF5)
 
   set(HDF5_NEED_ZLIB "OFF" CACHE BOOL "Does the HDF5 library require linking to zlib?")
   if(HDF5_NEED_ZLIB)
-    find_package(ZLIB)   # more recent versions of HDF5 require ZLIB::ZLIB
     find_library(ZLIB_LIBRARY z)
     mark_as_advanced(CLEAR ZLIB_LIBRARY)
   else ()
@@ -411,6 +410,17 @@ if (CGNS_ENABLE_HDF5)
 			    INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_STATIC_LIB)
     endif()
   endif ()
+
+  # If HDF5 needs ZLIB, a ZLIB:ZLIB target interface can pop up for hdf5
+  get_target_property(check_hdf5_link_defs hdf5-${CG_HDF5_LINK_TYPE} INTERFACE_LINK_LIBRARIES)
+  if (check_hdf5_link_defs)
+     if ("$<LINK_ONLY:ZLIB::ZLIB>" IN_LIST check_hdf5_link_defs)
+        # ZLIB_ROOT could be set outside
+        # ZLIB_USE_STATIC_LIBS could be set outside
+        find_package(ZLIB)
+     endif()
+  endif()
+
 else ()
   mark_as_advanced(FORCE HDF5_NEED_ZLIB HDF5_NEED_SZIP HDF5_NEED_MPI)
   mark_as_advanced(FORCE ZLIB_LIBRARY SZIP_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,7 @@ if (CGNS_ENABLE_HDF5)
 
   set(HDF5_NEED_ZLIB "OFF" CACHE BOOL "Does the HDF5 library require linking to zlib?")
   if(HDF5_NEED_ZLIB)
+    find_package(ZLIB)   # more recent versions of HDF5 require ZLIB::ZLIB
     find_library(ZLIB_LIBRARY z)
     mark_as_advanced(CLEAR ZLIB_LIBRARY)
   else ()


### PR DESCRIPTION
When I build CGNS with more recent versions of HDF5 I get the error message shown below.   This adds a call to `find_package(ZLIB)` that detects the `ZLIB::ZLIB` target.

```
CMake Error at /CGNS/build/CMakeFiles/CMakeTmp/cmTC_417f5Targets.cmake:21 (set_target_properties):
  The link interface of target "hdf5-static" contains:

    ZLIB::ZLIB

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
/CGNS/build/CMakeFiles/CMakeTmp/CMakeLists.txt:15 (include)


CMake Error at src/CMakeLists.txt:388 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  src/CMakeLists.txt:476 (CHECK_HDF5_FEATURE)
```