### PR TITLE
Some cmake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,15 +21,7 @@ set_cgns_build_type()
 
 project("cgns" C)
 
-if (WIN32)
-  set(${CMAKE_INSTALL_LIBDIR} "lib")
-  set(${CMAKE_INSTALL_DATADIR} "share")
-  set(${CMAKE_INSTALL_INCLUDEDIR} "include")
-  set(${CMAKE_INSTALL_BINDIR} "bin")
-  message(STATUS "Setting installation destination on Windows to: ${CMAKE_INSTALL_PREFIX}")
-else()
-  include(GNUInstallDirs)
-endif()
+include(GNUInstallDirs)
 
 # Determine CGNS_VERSION from src/cgnslib.h for 
 file (READ ${PROJECT_SOURCE_DIR}/src/cgnslib.h _cgnslib_h_contents)
@@ -86,6 +78,16 @@ option(CGNS_ENABLE_LEGACY "Enable or disable building legacy code (3.0 compatibl
 option(CGNS_ENABLE_SCOPING "Enable or disable scoping of enumeration values" "OFF")
 option(CGNS_ENABLE_BASE_SCOPE "Enable or disable base scoped families or connectivities" "OFF")
 option(CGNS_ENABLE_MEM_DEBUG "Enable or disable memory debugging" "OFF")
+
+set(tools_install_suffix "/cgnstools")
+if(WIN32)
+  set(tools_install_suffix "")
+endif()
+
+set(CGNS_INSTALL_TOOLS_BINDIR "${CMAKE_INSTALL_BINDIR}${install_suffix}" CACHE PATH
+    "CGNS: tools binary install location")
+set(CGNS_INSTALL_TOOLS_DATADIR "${CMAKE_INSTALL_DATADIR}${install_suffix}" CACHE PATH
+    "CGNS: arch independent tools data install location")
 
 set(CGNS_BUILD_SHARED "ON" CACHE BOOL "Build a shared version of the library")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,4 @@
 cmake_minimum_required(VERSION 3.20)
-if(COMMAND cmake_policy)
-  cmake_policy(SET CMP0003 NEW)
-endif()
-
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10")
-  cmake_policy(SET CMP0015 NEW)
-endif()
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
-  cmake_policy(SET CMP0081 NEW)
-endif()
 
 # Macro to handle muticonfig generator
 macro (SET_CGNS_BUILD_TYPE)
@@ -268,15 +258,6 @@ if (CGNS_ENABLE_HDF5)
   message (STATUS "HDF5 find comps: ${FIND_HDF_COMPONENTS}")
 
   set (SEARCH_PACKAGE_NAME "hdf5")
-  
-  # If the first `find_package` below does not succeed, then the legacy `find_package`
-  # is tried (the `else` below).  The legacy find_package uses `HDF5_ROOT`.  But if 
-  # this is set, then CMake will issue warning and mistakenly say that `HDF5_ROOT` is
-  # not used even though it might be.  This can confuse user, so set policy to not
-  # issue that warning.
-  if (${CMAKE_VERSION} VERSION_GREATER "3.13")
-     cmake_policy(SET CMP0074 NEW)
-  endif()
 
   find_package (HDF5 NAMES ${SEARCH_PACKAGE_NAME} COMPONENTS ${FIND_HDF_COMPONENTS})
   message (STATUS "HDF5 C libs:${HDF5_FOUND} static:${HDF5_static_C_FOUND} and shared:${HDF5_shared_C_FOUND}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20...3.20)
 
 # Macro to handle muticonfig generator
 macro (SET_CGNS_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,34 +1,23 @@
 cmake_minimum_required(VERSION 3.20...3.20)
 
-# Macro to handle muticonfig generator
-macro (SET_CGNS_BUILD_TYPE)
+# Function to handle muticonfig generator
+function(set_cgns_build_type)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build.")
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+      "MinSizeRel" "RelWithDebInfo")
   get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
   if(_isMultiConfig)
-    set(CGNS_CFG_NAME ${CMAKE_BUILD_TYPE})
-    set(CGNS_BUILD_TYPE ${CMAKE_CFG_INTDIR})
-    set(CGNS_CFG_BUILD_TYPE \${CMAKE_INSTALL_CONFIG_NAME})
+    set(CGNS_BUILD_TYPE ${CMAKE_CFG_INTDIR} PARENT_SCOPE)
+    set(CGNS_CFG_BUILD_TYPE \${CMAKE_INSTALL_CONFIG_NAME} PARENT_SCOPE)
   else()
-    set(CGNS_CFG_BUILD_TYPE ".")
-    if(CMAKE_BUILD_TYPE)
-      set(CGNS_CFG_NAME ${CMAKE_BUILD_TYPE})
-      set(CGNS_BUILD_TYPE ${CMAKE_BUILD_TYPE})
-    else()
-      set(CGNS_CFG_NAME "Release")
-      set(CGNS_BUILD_TYPE "Release")
-    endif()
+    set(CGNS_CFG_BUILD_TYPE "." PARENT_SCOPE)
+    set(CGNS_BUILD_TYPE ${CMAKE_BUILD_TYPE} PARENT_SCOPE)
   endif()
-  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
-      message (VERBOSE "Setting build type to 'Release' as none was specified.")
-    endif()
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
-    # Set the possible values of build type for cmake-gui
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
-      "MinSizeRel" "RelWithDebInfo")
-  endif()
-endmacro ()
+  set(CGNS_CFG_NAME ${CMAKE_BUILD_TYPE} PARENT_SCOPE)
+endfunction()
 
-SET_CGNS_BUILD_TYPE()
+set_cgns_build_type()
 
 project("cgns" C)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -702,11 +702,7 @@ endif ()
 # Set the install path of the static and shared library
 # for windows, need to install both cgnsdll.dll and cgnsdll.lib
 install (TARGETS ${install_targets}
-         EXPORT cgns-targets
-         LIBRARY DESTINATION lib COMPONENT libraries
-         ARCHIVE DESTINATION lib COMPONENT libraries
-         RUNTIME DESTINATION bin COMPONENT libraries
-         INCLUDES DESTINATION include)
+         EXPORT cgns-targets)
 
 # Set the install path of the header files
 set(headers
@@ -745,7 +741,7 @@ endif ()
 
 # Set the install path of the header files
 install(FILES ${headers}
-	DESTINATION include)
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 #if (NOT CGNS_EXTERNALLY_CONFIGURE)
 include(CMakePackageConfigHelpers)
@@ -756,14 +752,14 @@ write_basic_package_version_file(
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cgns-config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/cgns-config.cmake
-  INSTALL_DESTINATION lib/cmake/cgns )
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cgns )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cgns-config-version.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/cgns-config.cmake
-	DESTINATION lib/cmake/cgns)
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cgns)
 install(EXPORT cgns-targets
 	FILE cgns-targets.cmake
 	NAMESPACE CGNS::
-	DESTINATION lib/cmake/cgns
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cgns
 	)
 #endif()
 

--- a/src/cgnstools/CMakeLists.txt
+++ b/src/cgnstools/CMakeLists.txt
@@ -91,8 +91,8 @@ endif ()
 if (WIN32)
   file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX} WIN_INSTALL_DIR)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cgconfig.bat
-"set CG_BIN_DIR=${WIN_INSTALL_DIR}\\bin
-set CG_LIB_DIR=${WIN_INSTALL_DIR}\\share
+"set CG_BIN_DIR=${WIN_INSTALL_DIR}\\${CGNS_INSTALL_TOOLS_BINDIR}
+set CG_LIB_DIR=${WIN_INSTALL_DIR}\\${CGNS_INSTALL_TOOLS_DATADIR}
 ")
 # don't need this since dll is put in the bin directory
 #  if (CGNS_USE_SHARED)
@@ -111,15 +111,28 @@ set CG_LIB_DIR=${WIN_INSTALL_DIR}\\share
 
   install(PROGRAMS
 	${CMAKE_CURRENT_BINARY_DIR}/cgconfig.bat
-	DESTINATION bin)
+	TYPE BIN)
 else ()
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cgconfig
-"CG_BIN_DIR=${CMAKE_INSTALL_PREFIX}/bin; export CG_BIN_DIR
-CG_LIB_DIR=${CMAKE_INSTALL_PREFIX}/share/cgnstools; export CG_LIB_DIR
+"CG_BIN_DIR=${CMAKE_INSTALL_PREFIX}/${CGNS_INSTALL_TOOLS_BINDIR}; export CG_BIN_DIR
+CG_LIB_DIR=${CMAKE_INSTALL_PREFIX}/${CGNS_INSTALL_TOOLS_DATADIR}; export CG_LIB_DIR
 ")
 
   install(PROGRAMS
 	${CMAKE_CURRENT_BINARY_DIR}/cgconfig
-	DESTINATION bin)
+	TYPE BIN)
 endif ()
 
+# Because of the hard-coding above, the package is not relocatable
+# This can be avoided using `cmake_path(RELATIVE_PATH)` or writing the
+# files at install time.
+install(CODE [===[
+if (DEFINED CACHE{CMAKE_INSTALL_PREFIX})
+    message(FATAL_ERROR
+        "CGNS is not relocatable.\n"
+        "Overwriting the install location with `cmake --install --prefix` is not supported.\n"
+        "Please re-run the configure/build/install with the CMAKE_INSTALL_PREFIX set to desired location."
+        )
+endif ()
+]===]
+)

--- a/src/cgnstools/cgnscalc/CMakeLists.txt
+++ b/src/cgnstools/cgnscalc/CMakeLists.txt
@@ -56,44 +56,29 @@ if (WIN32)
   	LINK_FLAGS /subsystem:windows)
 endif ()
 
-if (WIN32)
-  install(TARGETS
+install(TARGETS
 	calcwish
-	RUNTIME DESTINATION bin)
+	RUNTIME DESTINATION ${CGNS_INSTALL_TOOLS_BINDIR})
+if (WIN32)
   install(PROGRAMS
 	cgnscalc.bat
 	unitconv.bat
-	DESTINATION bin)
-  install(FILES
-	cgnscalc.tcl
-	unitconv.tcl
-	cgnscalc.ico
-	cgnscalc.png
-	cgnscalc-icon.xbm
-	cgnscalc-mask.xbm
-	unitconv.ico
-	unitconv.png
-	unitconv.xbm
-	DESTINATION share)
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
 else ()
-  install(TARGETS
-	calcwish
-	RUNTIME DESTINATION bin/cgnstools)
   install(PROGRAMS
 	cgnscalc.sh
-	DESTINATION bin
+	TYPE BIN
 	RENAME cgnscalc)
   install(PROGRAMS
-	cgnscalc.desktop
-	DESTINATION bin)
-  install(PROGRAMS
 	unitconv.sh
-	DESTINATION bin
+	TYPE BIN
 	RENAME unitconv)
   install(PROGRAMS
+	cgnscalc.desktop
 	unitconv.desktop
-	DESTINATION bin)
-  install(FILES
+	TYPE BIN)
+endif ()
+install(FILES
 	cgnscalc.tcl
 	unitconv.tcl
 	cgnscalc.ico
@@ -103,6 +88,4 @@ else ()
 	unitconv.ico
 	unitconv.png
 	unitconv.xbm
-	DESTINATION share/cgnstools)
-endif ()
-
+	DESTINATION ${CGNS_INSTALL_TOOLS_DATADIR})

--- a/src/cgnstools/cgnsplot/CMakeLists.txt
+++ b/src/cgnstools/cgnsplot/CMakeLists.txt
@@ -63,37 +63,26 @@ if (WIN32)
   	LINK_FLAGS /subsystem:windows)
 endif ()
 
+install(TARGETS
+  plotwish
+  RUNTIME DESTINATION ${CGNS_INSTALL_TOOLS_BINDIR})
 if (WIN32)
-  install(TARGETS
-	plotwish
-	RUNTIME DESTINATION bin)
   install(PROGRAMS
 	cgnsplot.bat
-	DESTINATION bin)
-  install(FILES
-	cgnsplot.tcl
-	cgnsplot.ico
-	cgnsplot.png
-	cgnsplot-icon.xbm
-	cgnsplot-mask.xbm
-	DESTINATION share)
+	TYPE BIN)
 else ()
-  install(TARGETS
-	plotwish
-	RUNTIME DESTINATION bin/cgnstools)
   install(PROGRAMS
 	cgnsplot.sh
-	DESTINATION bin
+	TYPE BIN
 	RENAME cgnsplot)
   install(PROGRAMS
 	cgnsplot.desktop
-	DESTINATION bin)
-  install(FILES
-	cgnsplot.tcl
-	cgnsplot.ico
-	cgnsplot.png
-	cgnsplot-icon.xbm
-	cgnsplot-mask.xbm
-	DESTINATION share/cgnstools)
+	TYPE BIN)
 endif ()
-
+install(FILES
+  cgnsplot.tcl
+  cgnsplot.ico
+  cgnsplot.png
+  cgnsplot-icon.xbm
+  cgnsplot-mask.xbm
+  DESTINATION ${CGNS_INSTALL_TOOLS_DATADIR})

--- a/src/cgnstools/cgnsview/CMakeLists.txt
+++ b/src/cgnstools/cgnsview/CMakeLists.txt
@@ -60,47 +60,33 @@ if (WIN32)
   	LINK_FLAGS /subsystem:windows)
 endif ()
 
+install(TARGETS
+  cgiowish
+  RUNTIME DESTINATION ${CGNS_INSTALL_TOOLS_BINDIR})
 if (WIN32)
-  install(TARGETS
-	cgiowish
-	RUNTIME DESTINATION bin)
   install(PROGRAMS
 	cgnsview.bat
 	cgnsnodes.bat
-	DESTINATION bin)
-  install(FILES
-	cgnsview.tcl
-	cgns.tcl
-	cgnsnodes.tcl
-	export.tcl
-	import.tcl
-	tools.tcl
-	DESTINATION share)
+	TYPE BIN)
 else ()
-  install(TARGETS
-	cgiowish
-	RUNTIME DESTINATION bin/cgnstools)
   install(PROGRAMS
 	cgnsview.sh
-	DESTINATION bin
+	TYPE BIN
 	RENAME cgnsview)
   install(PROGRAMS
+    cgnsnodes.sh
+    TYPE BIN
+    RENAME cgnsnodes)
+  install(PROGRAMS
 	cgnsview.desktop
-	DESTINATION bin)
-  install(PROGRAMS
-	cgnsnodes.sh
-	DESTINATION bin
-	RENAME cgnsnodes)
-  install(PROGRAMS
-	cgnsnodes.desktop
-	DESTINATION bin)
-  install(FILES
-	cgnsview.tcl
-	cgns.tcl
-	cgnsnodes.tcl
-	export.tcl
-	import.tcl
-	tools.tcl
-	DESTINATION share/cgnstools)
-endif () 
-
+    cgnsnodes.desktop
+	TYPE BIN)
+endif ()
+install(FILES
+  cgnsview.tcl
+  cgns.tcl
+  cgnsnodes.tcl
+  export.tcl
+  import.tcl
+  tools.tcl
+  DESTINATION ${CGNS_INSTALL_TOOLS_DATADIR})

--- a/src/cgnstools/common/CMakeLists.txt
+++ b/src/cgnstools/common/CMakeLists.txt
@@ -2,51 +2,25 @@
 # common #
 ##########
 
-if (WIN32)
-  install(FILES
-	balloon.tcl
-	color.tcl
-	combobox.tcl
-	config.tcl
-	dialog.tcl
-	editfile.tcl
-	filesel.tcl
-	findfile.tcl
-	frame.tcl
-	help.tcl
-	menubar.tcl
-	tclIndex
-	tclreg.tcl
-	tkdir.tcl
-	tree.tcl
-	units.tcl
-	cgns.ico
-	cgns.png
-	cgns-icon.xbm
-	cgns-mask.xbm
-	DESTINATION share)
-else ()
-  install(FILES
-	balloon.tcl
-	color.tcl
-	combobox.tcl
-	config.tcl
-	dialog.tcl
-	editfile.tcl
-	filesel.tcl
-	findfile.tcl
-	frame.tcl
-	help.tcl
-	menubar.tcl
-	tclIndex
-	tclreg.tcl
-	tkdir.tcl
-	tree.tcl
-	units.tcl
-	cgns.ico
-	cgns.png
-	cgns-icon.xbm
-	cgns-mask.xbm
-	DESTINATION share/cgnstools)
-endif ()
-
+install(FILES
+  balloon.tcl
+  color.tcl
+  combobox.tcl
+  config.tcl
+  dialog.tcl
+  editfile.tcl
+  filesel.tcl
+  findfile.tcl
+  frame.tcl
+  help.tcl
+  menubar.tcl
+  tclIndex
+  tclreg.tcl
+  tkdir.tcl
+  tree.tcl
+  units.tcl
+  cgns.ico
+  cgns.png
+  cgns-icon.xbm
+  cgns-mask.xbm
+  DESTINATION ${CGNS_INSTALL_TOOLS_DATADIR})

--- a/src/cgnstools/utilities/CMakeLists.txt
+++ b/src/cgnstools/utilities/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(cgns_info PRIVATE ${UTILITIES_LK_LIBS})
 #----------
 
 # plot3d_to_cgns
-set(plot3d_to_cgns_FILES 
+set(plot3d_to_cgns_FILES
 	plot3d_to_cgns.c
 	cgnsutil.c
 	binaryio.c
@@ -53,7 +53,7 @@ add_executable(plot3d_to_cgns ${plot3d_to_cgns_FILES})
 target_link_libraries(plot3d_to_cgns PRIVATE ${UTILITIES_LK_LIBS})
 
 # cgns_to_plot3d
-set(cgns_to_plot3d_FILES 
+set(cgns_to_plot3d_FILES
 	cgns_to_plot3d.c
 	cgnsutil.c
 	binaryio.c
@@ -66,7 +66,7 @@ target_link_libraries(cgns_to_plot3d PRIVATE ${UTILITIES_LK_LIBS})
 #----------
 
 # patran_to_cgns
-set(patran_to_cgns_FILES 
+set(patran_to_cgns_FILES
 	patran_to_cgns.c
 	cgnsImport.c
 	../common/getargs.c
@@ -222,81 +222,40 @@ set(update_ngon_FILES
 add_executable(update_ngon ${update_ngon_FILES})
 target_link_libraries(update_ngon PRIVATE ${UTILITIES_LK_LIBS})
 
-if (WIN32)
-  install(TARGETS
-        plot3d_to_cgns
-	cgns_to_plot3d
-	patran_to_cgns
-	tecplot_to_cgns
-	cgns_to_tecplot
-	tetgen_to_cgns
-	vgrid_to_cgns
-	aflr3_to_cgns
-	cgns_to_aflr3
-	fast_to_cgns
-	cgns_to_fast
-	cgns_to_vtk
-	convert_location
-	convert_variables
-	convert_dataclass
-	extract_subset
-	interpolate_cgns
-	update_ngon
-        cgns_info
-	RUNTIME DESTINATION bin)
-  install(FILES
-	conserved.cnv
-	convert.tcl
-	dimensional.cnv
-	patran.tcl
-	plot3d.tcl
-	primitive.cnv
-	tecplot.tcl
-	tetgen.tcl
-	vgrid.tcl
-	aflr3.tcl
-	fast.tcl
-	util.tcl
-	utilities.mnu
-	vtk.tcl
-	DESTINATION share)
-else ()
-  install(TARGETS
-        plot3d_to_cgns
-	cgns_to_plot3d
-	patran_to_cgns
-	tecplot_to_cgns
-	cgns_to_tecplot
-	tetgen_to_cgns
-	vgrid_to_cgns
-	aflr3_to_cgns
-	cgns_to_aflr3
-	fast_to_cgns
-	cgns_to_fast
-	cgns_to_vtk
-	convert_location
-	convert_variables
-	convert_dataclass
-	extract_subset
-	interpolate_cgns
-	update_ngon
-        cgns_info
-	RUNTIME DESTINATION bin/cgnstools)
-  install(FILES
-	conserved.cnv
-	convert.tcl
-	dimensional.cnv
-	patran.tcl
-	plot3d.tcl
-	primitive.cnv
-	tecplot.tcl
-	tetgen.tcl
-	vgrid.tcl
-	aflr3.tcl
-	fast.tcl
-	util.tcl
-	utilities.mnu
-	vtk.tcl
-	DESTINATION share/cgnstools)
-endif ()
-
+install(TARGETS
+			plot3d_to_cgns
+cgns_to_plot3d
+patran_to_cgns
+tecplot_to_cgns
+cgns_to_tecplot
+tetgen_to_cgns
+vgrid_to_cgns
+aflr3_to_cgns
+cgns_to_aflr3
+fast_to_cgns
+cgns_to_fast
+cgns_to_vtk
+convert_location
+convert_variables
+convert_dataclass
+extract_subset
+interpolate_cgns
+update_ngon
+			cgns_info
+RUNTIME DESTINATION ${CGNS_INSTALL_TOOLS_BINDIR})
+install(FILES
+conserved.cnv
+convert.tcl
+dimensional.cnv
+patran.tcl
+plot3d.tcl
+primitive.cnv
+tecplot.tcl
+tetgen.tcl
+vgrid.tcl
+aflr3.tcl
+fast.tcl
+util.tcl
+utilities.mnu
+vtk.tcl
+DESTINATION ${CGNS_INSTALL_TOOLS_DATADIR})

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -72,27 +72,27 @@ install(TARGETS
 	cgnslist
 	cgnsnames
 	cgnscompress
-	RUNTIME DESTINATION bin)
+)
 
 if (WIN32)
   install(PROGRAMS
         cgnsupdate.bat
-	DESTINATION bin)
+	TYPE BIN)
   if (CGNS_ENABLE_HDF5)
     install(PROGRAMS
         adf2hdf.bat
         hdf2adf.bat
-	DESTINATION bin)
+	TYPE BIN)
   endif ()
 else ()
   install(PROGRAMS
         cgnsupdate
-	DESTINATION bin)
+	TYPE BIN)
   if (CGNS_ENABLE_HDF5)
     install(PROGRAMS
         adf2hdf
         hdf2adf
-	DESTINATION bin)
+	TYPE BIN)
   endif ()
 endif ()
 


### PR DESCRIPTION
- Add higher-bound to the CMake policies. I highly encourage to add 3 CMake builders (lowest policy, highest policy, latest-rc)
- Always use GNUInstallDirs
- Drive-by simplify `set_cgns_build_type`. I don't actually see the variables being used, and I believe the multi-config defaults are missing, but I will leave it for upstream to decide what to do with it