### PR TITLE
clean cgnstools from old _ANSI_ tricks for a better tcl compatibility

### DIFF
--- a/src/cgnstools/cgnscalc/calctcl.c
+++ b/src/cgnstools/cgnscalc/calctcl.c
@@ -8,8 +8,8 @@
 #include "calc.h"
 #include "cgnslib.h"
 
-#ifndef CONST
-# define CONST
+#ifndef Tcl_Size
+# define Tcl_Size int
 #endif
 
 static Tcl_Interp *global_interp;
@@ -704,8 +704,9 @@ static int CalcCommand (ClientData data, Tcl_Interp *interp,
 static int CalcDelete (ClientData data, Tcl_Interp *interp,
                        int argc, char **argv)
 {
-    int i, n, nargs;
-    CONST char **args;
+    int i, n;
+    Tcl_Size nargs;
+    const char **args;
 
     for (n = 1; n < argc; n++) {
         if (TCL_OK == Tcl_SplitList (interp, argv[n], &nargs, &args)) {

--- a/src/cgnstools/cgnscalc/calcwish.c
+++ b/src/cgnstools/cgnscalc/calcwish.c
@@ -16,11 +16,11 @@
 #include "locale.h"
 
 #ifdef TK_TEST
-extern int		Tcltest_Init _ANSI_ARGS_((Tcl_Interp *interp));
-extern int		Tktest_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int		Tcltest_Init (Tcl_Interp *interp);
+extern int		Tktest_Init (Tcl_Interp *interp);
 #endif /* TK_TEST */
 
-extern int Calctcl_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int Calctcl_Init (Tcl_Interp *interp);
 
 /*
  *----------------------------------------------------------------------
@@ -54,7 +54,7 @@ main(argc, argv)
 #ifndef TK_LOCAL_APPINIT
 #define TK_LOCAL_APPINIT Tcl_AppInit
 #endif
-    extern int TK_LOCAL_APPINIT _ANSI_ARGS_((Tcl_Interp *interp));
+    extern int TK_LOCAL_APPINIT (Tcl_Interp *interp);
 
     /*
      * The following #if block allows you to change how Tcl finds the startup
@@ -63,7 +63,7 @@ main(argc, argv)
      */
 
 #ifdef TK_LOCAL_MAIN_HOOK
-    extern int TK_LOCAL_MAIN_HOOK _ANSI_ARGS_((int *argc, char ***argv));
+    extern int TK_LOCAL_MAIN_HOOK (int *argc, char ***argv);
     TK_LOCAL_MAIN_HOOK(&argc, &argv);
 #endif
 

--- a/src/cgnstools/cgnscalc/cgnscalc.tcl
+++ b/src/cgnstools/cgnscalc/cgnscalc.tcl
@@ -8,7 +8,7 @@ proc error_exit {msg} {
   exit 1
 }
 
-if {[catch {package require Tk 8.0} msg]} {
+if {[catch {package vsatisfies [package provide Tcl] 8.6 9} msg]} {
   error_exit $msg
 }
 

--- a/src/cgnstools/cgnscalc/unitconv.tcl
+++ b/src/cgnstools/cgnscalc/unitconv.tcl
@@ -8,7 +8,7 @@ proc error_exit {msg} {
   exit 1
 }
 
-if {[catch {package require Tk 8.0} msg]} {
+if {[catch {package vsatisfies [package provide Tcl] 8.6 9} msg]} {
   error_exit $msg
 }
 

--- a/src/cgnstools/cgnscalc/winmain.c
+++ b/src/cgnstools/cgnscalc/winmain.c
@@ -19,19 +19,19 @@
 #include <malloc.h>
 #include <locale.h>
 
-extern int Calctcl_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int Calctcl_Init (Tcl_Interp *interp);
 #ifdef USE_HTMLHELP
-extern int WinHtml_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int WinHtml_Init (Tcl_Interp *interp);
 #endif
 
 /*
  * Forward declarations for procedures defined later in this file:
  */
 
-static void setargv _ANSI_ARGS_((int *argcPtr, char ***argvPtr));
-static void WishPanic _ANSI_ARGS_(TCL_VARARGS(char *,format));
-static int Proc_LoadIcon _ANSI_ARGS_((ClientData data,
-    Tcl_Interp *interp, int argc, char **argv));
+static void setargv (int *argcPtr, char ***argvPtr);
+static void WishPanic (TCL_VARARGS(char *,format));
+static int Proc_LoadIcon (ClientData data,
+    Tcl_Interp *interp, int argc, char **argv);
 
 static HINSTANCE myInstance;
 

--- a/src/cgnstools/cgnsplot/cgnsplot.tcl
+++ b/src/cgnstools/cgnsplot/cgnsplot.tcl
@@ -8,7 +8,7 @@ proc error_exit {msg} {
   exit 1
 }
 
-if {[catch {package require Tk 8.0} msg]} {
+if {[catch {package vsatisfies [package provide Tcl] 8.6 9} msg]} {
   error_exit $msg
 }
 
@@ -2100,7 +2100,7 @@ proc cutplane_control {} {
   center_cutplane
   reset_cutplane
   foreach i {x y z d} {
-    trace variable ProgData(cut$i) w update_cutplane
+    trace add variable ProgData(cut$i) write update_cutplane
   }
   set ProgData(dotrace) 1
 }
@@ -2110,7 +2110,7 @@ proc close_cutplane {} {
   if {[winfo exists .cutplane]} {
     set ProgData(dotrace) 1
     foreach i {x y z d} {
-      trace vdelete ProgData(cut$i) w update_cutplane
+      trace remove variable ProgData(cut$i) write update_cutplane
     }
     OGLcutplane 0
     OGLdrawplane

--- a/src/cgnstools/cgnsplot/cgnstcl.c
+++ b/src/cgnstools/cgnsplot/cgnstcl.c
@@ -13,6 +13,10 @@
 #include "cgnslib.h"
 #include "hash.h"
 
+#ifndef Tcl_Size
+# define Tcl_Size int
+#endif
+
 #ifdef CG_BUILD_BASESCOPE
 typedef char char_66[66]; /* 32 + '/' + 32 + '\0' */
 #else
@@ -3812,8 +3816,9 @@ static void transform_bounds (float m[16], float bb[3][2])
 static int CGNSbounds (ClientData data, Tcl_Interp *interp, int argc, char **argv)
 {
     float bbox[3][2], matrix[16];
-    int n, all = 0;
-    CONST char **args;
+    int all = 0;
+    Tcl_Size n = 0;
+    const char **args;
     char sbb[65];
 
     if (argc > 1) all = atoi(argv[1]);
@@ -3840,8 +3845,9 @@ static int CGNSbounds (ClientData data, Tcl_Interp *interp, int argc, char **arg
 
 static int OGLregion (ClientData data, Tcl_Interp *interp, int argc, char **argv)
 {
-    int zone, regn, nc;
-    CONST char **args;
+    int zone, regn;
+    Tcl_Size nc;
+    const char **args;
     Zone *z;
     Regn *r;
     static char slist[17];
@@ -3951,8 +3957,9 @@ static int OGLaxis (ClientData data, Tcl_Interp *interp, int argc, char **argv)
     glNewList (AxisDL, GL_COMPILE);
     if (vis) {
         if (argc == 3) {
-            int nb, n = 0;
-            CONST char **args;
+            int n = 0;
+	    Tcl_Size nb = 0;
+            const char **args;
             if (TCL_OK != Tcl_SplitList (interp, argv[2], &nb, &args))
                 return TCL_ERROR;
             if (nb == 3) {
@@ -5222,8 +5229,8 @@ static int OGLcutplane (ClientData data, Tcl_Interp *interp, int argc, char **ar
     mode = atoi(argv[1]);
 
     if (argc == 3) {
-        int np;
-        CONST char **args;
+        Tcl_Size np;
+        const char **args;
         if (TCL_OK != Tcl_SplitList (interp, argv[2], &np, &args))
             return TCL_ERROR;
         if (np != 4) {
@@ -5264,8 +5271,9 @@ static int OGLcutplane (ClientData data, Tcl_Interp *interp, int argc, char **ar
 
 static int OGLdrawplane (ClientData data, Tcl_Interp *interp, int argc, char **argv)
 {
-    int n, np, i, j, k, index, n0, n1;
-    CONST char **args;
+    int n, i, j, k, index, n0, n1;
+    Tcl_Size np;
+    const char **args;
     float plane[4], bbox[3][2], s[8], ds;
     float node[8][3], pnode[6][3];
     static char slist[17];
@@ -5362,8 +5370,9 @@ static int OGLdrawplane (ClientData data, Tcl_Interp *interp, int argc, char **a
 
 static int OGLcutconfig (ClientData data, Tcl_Interp *interp, int argc, char **argv)
 {
-    int n, np;
-    CONST char **args;
+    int n;
+    Tcl_Size np;
+    const char **args;
 
     if (argc < 2 || argc > 4) {
         Tcl_SetResult (interp, "usage: OGLcutconfig color [usecutclr] [ignorevis]",

--- a/src/cgnstools/cgnsplot/plotwish.c
+++ b/src/cgnstools/cgnsplot/plotwish.c
@@ -15,9 +15,10 @@
 #include "tk.h"
 #include "locale.h"
 
-extern int Cgnstcl_Init _ANSI_ARGS_((Tcl_Interp *interp));
-extern int Tkogl_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int Cgnstcl_Init (Tcl_Interp *interp);
+extern int Tkogl_Init (Tcl_Interp *interp);
 
+int Tcl_AppInit(Tcl_Interp *  interp);
 /*
  *----------------------------------------------------------------------
  *
@@ -36,9 +37,7 @@ extern int Tkogl_Init _ANSI_ARGS_((Tcl_Interp *interp));
  */
 
 int
-main(argc, argv)
-    int argc;			/* Number of command-line arguments. */
-    char **argv;		/* Values of command-line arguments. */
+main(int argc, char **argv)
 {
     Tk_Main(argc, argv, Tcl_AppInit);
     return 0;			/* Needed only to prevent compiler warning. */
@@ -64,9 +63,9 @@ main(argc, argv)
  */
 
 int
-Tcl_AppInit(interp)
-    Tcl_Interp *interp;		/* Interpreter for application. */
+Tcl_AppInit(Tcl_Interp *  interp)
 {
+    /* interp: Interpreter for application. */
     if (Tcl_Init(interp) == TCL_ERROR) {
 	return TCL_ERROR;
     }

--- a/src/cgnstools/cgnsplot/winmain.c
+++ b/src/cgnstools/cgnsplot/winmain.c
@@ -19,20 +19,20 @@
 #include <malloc.h>
 #include <locale.h>
 
-extern int Cgnstcl_Init _ANSI_ARGS_((Tcl_Interp *interp));
-extern int Tkogl_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int Cgnstcl_Init (Tcl_Interp *interp);
+extern int Tkogl_Init (Tcl_Interp *interp);
 #ifdef USE_HTMLHELP
-extern int WinHtml_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int WinHtml_Init (Tcl_Interp *interp);
 #endif
 
 /*
  * Forward declarations for procedures defined later in this file:
  */
 
-static void setargv _ANSI_ARGS_((int *argcPtr, char ***argvPtr));
-static void WishPanic _ANSI_ARGS_(TCL_VARARGS(char *,format));
-static int Proc_LoadIcon _ANSI_ARGS_((ClientData data,
-    Tcl_Interp *interp, int argc, char **argv));
+static void setargv (int *argcPtr, char ***argvPtr);
+static void WishPanic TCL_VARARGS(char *,format);
+static int Proc_LoadIcon (ClientData data,
+    Tcl_Interp *interp, int argc, char **argv);
 
 static HINSTANCE myInstance;
 

--- a/src/cgnstools/cgnsview/cgiotcl.c
+++ b/src/cgnstools/cgnsview/cgiotcl.c
@@ -13,8 +13,8 @@
 # define cgulong_t unsigned long
 #endif
 
-#ifndef CONST
-# define CONST
+#ifndef Tcl_Size
+# define Tcl_Size int
 #endif
 
 /* these are the data types as used in CGIO */
@@ -1526,11 +1526,11 @@ static int CGIOtype (ClientData data, Tcl_Interp *interp,
 static int CGIOdimensions (ClientData data, Tcl_Interp *interp,
     int argc, char **argv)
 {
-    int n;
-    int ndim;
+    int n, ndim;
+    Tcl_Size Tcl_ndim;
     cgsize_t dims[CGIO_MAX_DIMENSIONS];
     double node_id;
-    CONST char **args;
+    const char **args;
     char str[65];
 
     Tcl_ResetResult (interp);
@@ -1549,8 +1549,9 @@ static int CGIOdimensions (ClientData data, Tcl_Interp *interp,
     if (argc > 2) {
         if (cgio_get_data_type (cgioNum, node_id, str))
             return (get_error (interp, "cgio_get_data_type"));
-        if (TCL_OK != Tcl_SplitList (interp, argv[2], &ndim, &args))
+        if (TCL_OK != Tcl_SplitList (interp, argv[2], &Tcl_ndim, &args))
             return TCL_ERROR;
+	ndim = (int) Tcl_ndim;
         if (ndim > CGIO_MAX_DIMENSIONS) {
             Tcl_Free ((char *)args);
             Tcl_AppendResult (interp, "invalid number of dimensions", NULL);
@@ -1744,11 +1745,12 @@ static int CGIOread (ClientData data, Tcl_Interp *interp,
 static int CGIOwrite (ClientData data, Tcl_Interp *interp,
     int argc, char **argv)
 {
-    int n, nv, ns;
+    int n, ns;
     int ndim;
+    Tcl_Size nv, Tcl_ndim;
     cgsize_t np, dims[CGIO_MAX_DIMENSIONS];
     double node_id;
-    CONST char **args;
+    const char **args;
     char *values, type[CGIO_MAX_DATATYPE_LENGTH+1];
     struct DataType *dt = NULL;
 
@@ -1790,10 +1792,12 @@ static int CGIOwrite (ClientData data, Tcl_Interp *interp,
     /* get dimensions */
 
     ndim = 0;
+    Tcl_ndim = 0;
     args = NULL;
     if (argc > 3 &&
-        TCL_OK != Tcl_SplitList (interp, argv[3], &ndim, &args))
+        TCL_OK != Tcl_SplitList (interp, argv[3], &Tcl_ndim, &args))
         return TCL_ERROR;
+    if (Tcl_ndim != 0) ndim = (int) Tcl_ndim;
     if (ndim == 0) {
         if (cgio_set_dimensions (cgioNum, node_id, dt->name, ndim, dims))
             return (get_error (interp, "cgio_set_dimensions"));

--- a/src/cgnstools/cgnsview/cgiowish.c
+++ b/src/cgnstools/cgnsview/cgiowish.c
@@ -16,11 +16,11 @@
 #include "locale.h"
 
 #ifdef TK_TEST
-extern int		Tcltest_Init _ANSI_ARGS_((Tcl_Interp *interp));
-extern int		Tktest_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int		Tcltest_Init (Tcl_Interp *interp);
+extern int		Tktest_Init (Tcl_Interp *interp);
 #endif /* TK_TEST */
 
-extern int CGIOtcl_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int CGIOtcl_Init (Tcl_Interp *interp);
 
 /*
  *----------------------------------------------------------------------
@@ -54,7 +54,7 @@ main(argc, argv)
 #ifndef TK_LOCAL_APPINIT
 #define TK_LOCAL_APPINIT Tcl_AppInit
 #endif
-    extern int TK_LOCAL_APPINIT _ANSI_ARGS_((Tcl_Interp *interp));
+    extern int TK_LOCAL_APPINIT (Tcl_Interp *interp);
 
     /*
      * The following #if block allows you to change how Tcl finds the startup
@@ -63,7 +63,7 @@ main(argc, argv)
      */
 
 #ifdef TK_LOCAL_MAIN_HOOK
-    extern int TK_LOCAL_MAIN_HOOK _ANSI_ARGS_((int *argc, char ***argv));
+    extern int TK_LOCAL_MAIN_HOOK (int *argc, char ***argv);
     TK_LOCAL_MAIN_HOOK(&argc, &argv);
 #endif
 

--- a/src/cgnstools/cgnsview/cgnsnodes.tcl
+++ b/src/cgnstools/cgnsview/cgnsnodes.tcl
@@ -8,7 +8,7 @@ proc error_exit {msg} {
   exit 1
 }
 
-if {[catch {package require Tk 8.0} msg]} {
+if {[catch {package vsatisfies [package provide Tcl] 8.6 9} msg]} {
   error_exit $msg
 }
 

--- a/src/cgnstools/cgnsview/cgnsview.tcl
+++ b/src/cgnstools/cgnsview/cgnsview.tcl
@@ -8,7 +8,7 @@ proc error_exit {msg} {
   exit 1
 }
 
-if {[catch {package require Tk 8.0} msg]} {
+if {[catch {package vsatisfies [package provide Tcl] 8.6 9} msg]} {
   error_exit $msg
 }
 
@@ -1147,8 +1147,8 @@ proc set_perline {w} {
 
 #---------- update buttons when node changes
 
-trace variable Node(parent) w check_node
-trace variable Node(name) w check_node
+trace add variable Node(parent) write check_node
+trace add variable Node(name) write check_node
 
 #========== procedures ===============================================
 

--- a/src/cgnstools/cgnsview/winmain.c
+++ b/src/cgnstools/cgnsview/winmain.c
@@ -19,19 +19,19 @@
 #include <malloc.h>
 #include <locale.h>
 
-extern int CGIOtcl_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int CGIOtcl_Init (Tcl_Interp *interp);
 #ifdef USE_HTMLHELP
-extern int WinHtml_Init _ANSI_ARGS_((Tcl_Interp *interp));
+extern int WinHtml_Init (Tcl_Interp *interp);
 #endif
 
 /*
  * Forward declarations for procedures defined later in this file:
  */
 
-static void setargv _ANSI_ARGS_((int *argcPtr, char ***argvPtr));
-static void WishPanic _ANSI_ARGS_(TCL_VARARGS(char *,format));
-static int Proc_LoadIcon _ANSI_ARGS_((ClientData data,
-    Tcl_Interp *interp, int argc, char **argv));
+static void setargv (int *argcPtr, char ***argvPtr);
+static void WishPanic TCL_VARARGS(char *,format);
+static int Proc_LoadIcon (ClientData data,
+    Tcl_Interp *interp, int argc, char **argv);
 
 static HINSTANCE myInstance;
 

--- a/src/cgnstools/common/tree.tcl
+++ b/src/cgnstools/common/tree.tcl
@@ -531,7 +531,7 @@ proc TreeEdit {w v} {
   bind $ent <Return> "set _Tree($w:done) 1"
   set id [$w create window $x $y -window $frame -anchor w]
 
-  trace variable _Tree($w:edit) w "Tree:edit_size $w $ent $id $wmax"
+  trace add variable _Tree($w:edit) write "Tree:edit_size $w $ent $id $wmax"
   set oldFocus [focus]
   set oldGrab [grab current $w]
   if {$oldGrab != ""} {
@@ -544,7 +544,7 @@ proc TreeEdit {w v} {
   $ent icursor end
   $ent xview end
   tkwait variable _Tree($w:done)
-  trace vdelete _Tree($w:edit) w "Tree:edit_size $w $ent $id $wmax"
+  trace remove variable _Tree($w:edit) write "Tree:edit_size $w $ent $id $wmax"
 
   catch {focus $oldFocus}
   if {$oldGrab != ""} {

--- a/src/cgnstools/common/units.tcl
+++ b/src/cgnstools/common/units.tcl
@@ -793,7 +793,7 @@ proc units:create {top} {
   focus $w.values.input.ent
   $w.values.input.ent selection range 0 end
 
-  trace variable _UnitData(input:value) w "units:update {$w}"
+  trace add variable _UnitData(input:value) write "units:update {$w}"
 }
 
 proc units:invoke {but} {
@@ -812,7 +812,7 @@ proc units:destroy {top} {
   } else {
     set w $top
   }
-  trace vdelete _UnitData(input:value) w "units:update {$w}"
+  trace remove variable _UnitData(input:value) write "units:update {$w}"
   units:last $w
   destroy $top
 }

--- a/src/cgnstools/tkogl/gencyl.h
+++ b/src/cgnstools/tkogl/gencyl.h
@@ -1,3 +1,3 @@
-int GenericCylinder _ANSI_ARGS_((Tcl_Interp *interp, int argc, char* argv []));
+int GenericCylinder (Tcl_Interp *interp, int argc, char* argv []);
 
 

--- a/src/cgnstools/tkogl/glphoto.h
+++ b/src/cgnstools/tkogl/glphoto.h
@@ -1,3 +1,3 @@
-int glPhoto _ANSI_ARGS_((Tcl_Interp *interp, int argc, char* argv []));
+int glPhoto (Tcl_Interp *interp, int argc, char* argv []);
 
 

--- a/src/cgnstools/tkogl/load3ds.h
+++ b/src/cgnstools/tkogl/load3ds.h
@@ -1,5 +1,5 @@
-int glLoad3DStudio _ANSI_ARGS_ ((Tcl_Interp *interp,
+int glLoad3DStudio (Tcl_Interp *interp,
 				 int argc,
-				 char ** argv));
+				 char ** argv);
 
 

--- a/src/cgnstools/tkogl/tkogl.c
+++ b/src/cgnstools/tkogl/tkogl.c
@@ -28,9 +28,6 @@
 #include <tk-private/generic/tkInt.h>
 #endif
 
-#ifndef CONST
-# define CONST
-#endif
 
 /*
  * A data structure of the following type is kept for each glxwin
@@ -97,35 +94,35 @@ typedef struct {
 
 static Tk_ConfigSpec configSpecs[] = {
     {TK_CONFIG_PIXELS, "-height", "height", "Height",
-       "300" , Tk_Offset(OGLwin, height), 0},
+       "300" , offsetof(OGLwin, height), 0},
 
     {TK_CONFIG_PIXELS, "-width", "width", "Width",
-       "300" , Tk_Offset(OGLwin, width), 0},
+       "300" , offsetof(OGLwin, width), 0},
 
     {TK_CONFIG_STRING, "-context", "context", "Context",
-	NULL, Tk_Offset (OGLwin, context), TK_CONFIG_NULL_OK},
+	NULL, offsetof (OGLwin, context), TK_CONFIG_NULL_OK},
 
     {TK_CONFIG_BOOLEAN, "-doublebuffer", "doublebuffer", "DoubleBuffer",
-	"1", Tk_Offset (OGLwin, doubleBuffer), 0},
+	"1", offsetof (OGLwin, doubleBuffer), 0},
 
     {TK_CONFIG_INT, "-depthsize", "depthsize", "DepthSize",
-	"16", Tk_Offset (OGLwin, depthSize), 0},
+	"16", offsetof (OGLwin, depthSize), 0},
 
     {TK_CONFIG_INT, "-stencilsize", "stencilsize", "StencilSize",
-	"0", Tk_Offset (OGLwin, stencilSize), 0},
+	"0", offsetof (OGLwin, stencilSize), 0},
 
     {TK_CONFIG_INT, "-alphasize", "alphasize", "AlphaSize",
-	"0", Tk_Offset (OGLwin, alphaSize), 0},
+	"0", offsetof (OGLwin, alphaSize), 0},
 
     {TK_CONFIG_INT, "-accumsize", "accumsize", "AccumSize",
-	"0", Tk_Offset (OGLwin, accumSize), 0},
+	"0", offsetof (OGLwin, accumSize), 0},
 
     {TK_CONFIG_DOUBLE, "-aspectratio", "aspectratio", "AspectRatio",
-	"0", Tk_Offset (OGLwin, aspectRatio), 0},
+	"0", offsetof (OGLwin, aspectRatio), 0},
 
 
     {TK_CONFIG_BORDER, "-background", "background", "Background",
-	"#d9d9d9", Tk_Offset(OGLwin, bgBorder), 0},
+	"#d9d9d9", offsetof(OGLwin, bgBorder), 0},
 
 
     {TK_CONFIG_END, (char *) NULL, (char *) NULL, (char *) NULL,
@@ -136,19 +133,19 @@ static Tk_ConfigSpec configSpecs[] = {
  * Forward declarations for procedures defined later in this file:
  */
 
-static int	OGLwinConfigure _ANSI_ARGS_((Tcl_Interp *interp,
+static int	OGLwinConfigure (Tcl_Interp *interp,
 			    OGLwin *glxwinPtr, int argc, char **argv,
-			    int flags));
-static void	OGLwinDestroy _ANSI_ARGS_((char* clientData));
+			    int flags);
+static void	OGLwinDestroy (void* clientData);
 
-static void	OGLwinEventProc _ANSI_ARGS_((ClientData clientData,
-			    XEvent *eventPtr));
+static void	OGLwinEventProc (ClientData clientData,
+			    XEvent *eventPtr);
 
-static int	OGLwinWidgetCmd _ANSI_ARGS_((ClientData clientData,
-			    Tcl_Interp *, int argc, char **argv));
+static int	OGLwinWidgetCmd (ClientData clientData,
+			    Tcl_Interp *, int argc, char **argv);
 
 
-static void 	OGLwinRedraw _ANSI_ARGS_ ((ClientData clientData));
+static void 	OGLwinRedraw (ClientData clientData);
 
 int             OGLwinCmd(ClientData, Tcl_Interp*, int, char**);
 
@@ -167,8 +164,7 @@ static void     MakeCurrent (OGLwin* oglwinPtr);
     static void SetDCPixelFormat (OGLwin*);
 
 #else
-    static Colormap getColormap _ANSI_ARGS_((Display *dpy,
-						 XVisualInfo *vi));
+    static Colormap getColormap (Display *dpy, XVisualInfo *vi);
 #endif
 
 #define ERRMSG(msg) {\
@@ -1167,7 +1163,7 @@ OGLwinConfigure(interp, glxwinPtr, argc, argv, flags)
 					 * Tk_ConfigureWidget. */
 {
     if (Tk_ConfigureWidget(interp, glxwinPtr->tkwin, configSpecs,
-	    argc, (CONST char **)argv, (char *) glxwinPtr, flags) != TCL_OK) {
+	    argc, (void *)argv, (char *) glxwinPtr, flags|TK_CONFIG_OBJS) != TCL_OK) {
 	return TCL_ERROR;
     }
 
@@ -1251,7 +1247,7 @@ OGLwinEventProc(clientData, eventPtr)
 	    if (glxwinPtr->updatePending) {
     	   Tcl_CancelIdleCall(OGLwinRedraw, (ClientData) glxwinPtr);
         }
-	    Tcl_EventuallyFree((ClientData) glxwinPtr, OGLwinDestroy);
+	    Tcl_EventuallyFree((ClientData) glxwinPtr, (Tcl_FreeProc *)(void *)OGLwinDestroy);
     }
 
 }
@@ -1276,7 +1272,7 @@ OGLwinEventProc(clientData, eventPtr)
  */
 
 static void
-OGLwinDestroy(char* clientData)
+OGLwinDestroy(void* clientData)
 {
     OGLwin *glxwinPtr = (OGLwin *) clientData;
 

--- a/src/cgnstools/tkogl/tkoglparse.c
+++ b/src/cgnstools/tkogl/tkoglparse.c
@@ -675,7 +675,7 @@ ArgVarFloat (minArgs, maxArgs, def0, def1, def2, next)
  *
  *---------------------------------------------------------------------------*/
 
-typedef int TkOGLFunc _ANSI_ARGS_((Tcl_Interp* interp, void** args, int nargs));
+typedef int TkOGLFunc (Tcl_Interp* interp, void** args, int nargs);
 
 static TkOGLFunc
     TkAccum,

--- a/src/cgnstools/tkogl/tkoglparse.h
+++ b/src/cgnstools/tkogl/tkoglparse.h
@@ -1,14 +1,14 @@
 void InitHashTables ();
-int ParseGLFunc _ANSI_ARGS_((Tcl_Interp *interp,
+int ParseGLFunc (Tcl_Interp *interp,
 			     int argc,
 			     char *argv [],
-			     int *nArg));
-int SearchEnumVal _ANSI_ARGS_((Tcl_Interp* interp,
+			     int *nArg);
+int SearchEnumVal (Tcl_Interp* interp,
 			       char * name,
-			       GLenum* val));
-int SearchEnumName _ANSI_ARGS_((Tcl_Interp* interp,
+			       GLenum* val);
+int SearchEnumName (Tcl_Interp* interp,
 				GLenum val,
-				char ** name));
+				char ** name);
 
 
 


### PR DESCRIPTION
This cleaning should help a potential porting to tcl/tk 9 when needed.