### PR TITLE
Fix cgnsview HDF5 loading

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -2514,9 +2514,15 @@ void ADFH_Database_Valid(const char   *name,
         *err = NULL_STRING_POINTER;
     else
 #if ADFH_HDF5_HAVE_112_API
-        *err = H5Fis_accessible(name, H5P_DEFAULT);
+	if (H5Fis_accessible(name, H5P_DEFAULT) <=0)
+	  *err = ADFH_ERR_NOT_HDF5_FILE;
+	else
+	  *err = NO_ERROR;
 #else
-        *err = H5Fis_hdf5(name);
+        if (H5Fis_hdf5(name) <= 0)
+	  *err = ADFH_ERR_NOT_HDF5_FILE;
+	else
+	  *err = NO_ERROR;
 #endif
 }
 

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -615,23 +615,24 @@ int cgio_check_file (const char *filename, int *file_type)
     if(ctx_cgio.pcg_mpi_comm_rank == 0) {
 #endif
 #if CG_BUILD_HDF5
+      ADFH_Database_Valid(filename, &err);
       /* First try to open with HDF5 */
-      ADFH_Database_Open(filename, "READ_ONLY", ctx_cgio.hdf5_access, &rootid, &err);
+      /* ADFH_Database_Open(filename, "READ_ONLY", ctx_cgio.hdf5_access, &rootid, &err);*/
       if (err == 0) {
-        ADFH_Database_Close(rootid, &err);
-	if (err > 0) return set_error(err);
-	*file_type = CGIO_FILE_HDF5;
+        /* ADFH_Database_Close(rootid, &err); */
+        /* if (err > 0) return set_error(err); */
+        *file_type = CGIO_FILE_HDF5;
       }
       else {
       /* HDF5 did not work now try other cases */
 #endif
         fp = fopen(filename, "rb");
         if (NULL == fp) {
-	  if (errno == EMFILE) {
-	    err = set_error(CGIO_ERR_TOO_MANY);
-	  } else {
-	    err = set_error(CGIO_ERR_FILE_OPEN);
-	  }
+          if (errno == EMFILE) {
+            err = set_error(CGIO_ERR_TOO_MANY);
+          } else {
+            err = set_error(CGIO_ERR_FILE_OPEN);
+          }
           return err;
         }
         if (sizeof(buf) != fread (buf, 1, sizeof(buf), fp)) {
@@ -774,9 +775,9 @@ int cgio_open_file (const char *filename, int file_mode,
         case CGIO_MODE_MODIFY:
         case 'm':
         case 'M':
-	    fmode = "OLD";
-	    file_mode = CGIO_MODE_MODIFY;
-	    /* skip file checking if HDF5 requested */
+            fmode = "OLD";
+            file_mode = CGIO_MODE_MODIFY;
+            /* skip file checking if HDF5 requested */
             if (file_type == CGIO_FILE_HDF5)
                 break;
             if (cgio_check_file(filename, &type))

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -616,11 +616,7 @@ int cgio_check_file (const char *filename, int *file_type)
 #endif
 #if CG_BUILD_HDF5
       ADFH_Database_Valid(filename, &err);
-      /* First try to open with HDF5 */
-      /* ADFH_Database_Open(filename, "READ_ONLY", ctx_cgio.hdf5_access, &rootid, &err);*/
       if (err == 0) {
-        /* ADFH_Database_Close(rootid, &err); */
-        /* if (err > 0) return set_error(err); */
         *file_type = CGIO_FILE_HDF5;
       }
       else {


### PR DESCRIPTION
CGNSView is calling cgio_check_file multiple times... and it closes the file while loading it and building the tree.
The call is used by file_stats mainly but also other parts to get the file type (adf or hdf5). The CGNSview is not coded to be aware that it is requesting the file type of an already open file...
The CGIO level API has a similar issue. It tries to open the file to get it's type while not being aware that HDF5 library is  reusing an opened file and then just close it.
The propose fix is to do a less strong check.
