### PR TITLE
Remove debug message in cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,6 @@ elseif("${SIZEOF_LONG_LONG}" EQUAL "8")
 else()
   message(FATAL_ERROR "Can't find suitable int64_t")
 endif()
-message(STATUS "Found int64_t: ${CGLONGT}")
 
 set(BUILDLEGACY 0)
 set(BUILD64BIT 0)


### PR DESCRIPTION
This pull request includes a minor change to the `src/CMakeLists.txt` file. The change removes an unnecessary status message related to the detection of `int64_t`. 

It was first reported in VTK - https://gitlab.kitware.com/vtk/vtk/-/issues/19745