### PR TITLE
move the include for cgio_internal_type.h outside the conditional HDF5 block

### DIFF
--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -46,6 +46,7 @@ freely, subject to the following restrictions:
 #include "cgns_io.h"
 #include "cgnslib.h"
 #include "adf/ADF.h"
+#include "cgio_internal_type.h" /* for cgns_io_ctx_t */
 #if CG_BUILD_PARALLEL
 #include <mpi.h>
 #endif
@@ -54,7 +55,6 @@ freely, subject to the following restrictions:
 #if CG_BUILD_PARALLEL
 #include "hdf5.h"
 #endif
-#include "cgio_internal_type.h" /* for cgns_io_ctx_t */
 #endif
 
 #ifdef MEM_DEBUG

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -46,16 +46,14 @@ freely, subject to the following restrictions:
 #include "cgns_io.h"
 #include "cgnslib.h"
 #include "adf/ADF.h"
-#include "cgio_internal_type.h" /* for cgns_io_ctx_t */
 #if CG_BUILD_PARALLEL
 #include <mpi.h>
 #endif
 #if CG_BUILD_HDF5
 #include "adfh/ADFH.h"
-#if CG_BUILD_PARALLEL
 #include "hdf5.h"
 #endif
-#endif
+#include "cgio_internal_type.h" /* for cgns_io_ctx_t */
 
 #ifdef MEM_DEBUG
 #include "cg_malloc.h"


### PR DESCRIPTION
Fixes issues if HDF5 is not enabled.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `#include "cgio_internal_type.h"` outside HDF5 conditional block in `cgns_io.c` to fix issues when HDF5 is not enabled.
> 
>   - **Include Statement**:
>     - Move `#include "cgio_internal_type.h"` outside of the `#if CG_BUILD_HDF5` block in `cgns_io.c` to ensure `cgns_io_ctx_t` is always defined.
>   - **Behavior**:
>     - Fixes issues when HDF5 is not enabled by ensuring necessary types are always included.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for 9b7eb0aff85cad75f7e142c9cda395cd3a31c80a. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->