### PR TITLE
Reinvestigated #851

### DIFF
--- a/src/cgns-config.cmake.in
+++ b/src/cgns-config.cmake.in
@@ -65,59 +65,45 @@ foreach (comp IN LISTS ${CGNS_PACKAGE_NAME}_FIND_COMPONENTS)
   endif ()
 endforeach ()
 
-# Propagate HDF5 dependency
-set (HAVE_LK_HDF5_SHARED 0)
-if ((${CGNS_PACKAGE_NAME}_ENABLE_HDF5_SUPPORT) AND (${CGNS_PACKAGE_NAME}_HDF5_LINK_TYPE STREQUAL "shared"))
-  set (HAVE_LK_HDF5_SHARED 1)
-endif()
-if (HAVE_LK_HDF5_SHARED)
-  find_dependency(HDF5)
-  if (HDF5_FOUND)
-    # Handle case of partial hdf5 cmake config
-    if (NOT TARGET hdf5-shared)
-      message (STATUS " HDF5 was found but not hdf5-shared target, trying a fall back")
+#-----------------------------------------------------------------------------
+# Resolve HDF5 dependency BEFORE including cgns-targets.cmake
+# This ensures hdf5-static/hdf5-shared targets exist when cgns targets are loaded
+#-----------------------------------------------------------------------------
+if (${CGNS_PACKAGE_NAME}_ENABLE_HDF5_SUPPORT)
+  # Determine which HDF5 link type to find
+  if (${CGNS_PACKAGE_NAME}_HDF5_LINK_TYPE STREQUAL "shared")
+    set (HDF5_USE_STATIC_LIBRARIES OFF)
+    find_dependency(HDF5)
+    if (HDF5_FOUND AND NOT TARGET hdf5-shared)
+      message (STATUS " HDF5 was found but not hdf5-shared target, creating fallback target")
       add_library(hdf5-shared INTERFACE IMPORTED)
       string(REPLACE "-D" "" _hdf5_definitions "${HDF5_DEFINITIONS}")
       set_target_properties(hdf5-shared PROPERTIES
                           INTERFACE_LINK_LIBRARIES "${HDF5_LIBRARIES}"
                           INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}"
-                          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
-      set_target_properties(hdf5-shared PROPERTIES INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_DYNAMIC_LIB)
+                          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions};H5_BUILT_AS_DYNAMIC_LIB")
     endif()
-  endif()
-endif()
-# In case of static CGNS with static HDF5
-# How to propagate the dependency as it will be build environment dependent ?
-# Try to help the user.
-if ((${CGNS_PACKAGE_NAME}_ENABLE_HDF5_SUPPORT) AND (${CGNS_PACKAGE_NAME}_HDF5_LINK_TYPE STREQUAL "static"))
-  if ("static" IN_LIST ${CGNS_PACKAGE_NAME}_LIB_TYPE)
+  elseif (${CGNS_PACKAGE_NAME}_HDF5_LINK_TYPE STREQUAL "static")
     set (HDF5_USE_STATIC_LIBRARIES ON)
     find_dependency(HDF5)
-    if (HDF5_FOUND)
-      if (NOT TARGET hdf5-static)
-        message (STATUS " HDF5 was found but not hdf5-static target, trying a fall back")
-        add_library(hdf5-static STATIC IMPORTED)
-        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_DEFINITIONS}")
-        set_target_properties(hdf5-static PROPERTIES
+    if (HDF5_FOUND AND NOT TARGET hdf5-static)
+      message (STATUS " HDF5 was found but not hdf5-static target, creating fallback target")
+      add_library(hdf5-static INTERFACE IMPORTED)
+      string(REPLACE "-D" "" _hdf5_definitions "${HDF5_DEFINITIONS}")
+      set_target_properties(hdf5-static PROPERTIES
                           INTERFACE_LINK_LIBRARIES "${HDF5_LIBRARIES}"
                           INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}"
-                          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
-        set_target_properties(hdf5-static PROPERTIES INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_STATIC_LIB)
-      endif()
+                          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions};H5_BUILT_AS_STATIC_LIB")
       # If HDF5 needs ZLIB, but ZLIB is an external package not provided by hdf5
       # a ZLIB dependency should be added.
-      if (TARGET hdf5-static)
-        if (HDF5_ENABLE_ZLIB_SUPPORT AND NOT HDF5_PACKAGE_EXTLIBS)
-          message(STATUS "hdf5-static target needs ZLIB through an external library")
-          find_package(ZLIB)
-        endif ()
-        if (HDF5_ENABLE_SZIP_SUPPORT AND NOT HDF5_PACKAGE_EXTLIBS)
-          message(STATUS "hdf5-static target needs SZIP through external libraries")
-          find_package(libaec)
-        endif()
+      if (HDF5_ENABLE_ZLIB_SUPPORT AND NOT HDF5_PACKAGE_EXTLIBS)
+        message(STATUS "hdf5-static target needs ZLIB through an external library")
+        find_package(ZLIB)
+      endif ()
+      if (HDF5_ENABLE_SZIP_SUPPORT AND NOT HDF5_PACKAGE_EXTLIBS)
+        message(STATUS "hdf5-static target needs SZIP through external libraries")
+        find_package(libaec)
       endif()
-    else ()
-      message (FATAL_ERROR " HDF5 with hdf5-static target is required but was not found")
     endif()
   endif()
 endif()


### PR DESCRIPTION
The original code had nested conditions that prevented HDF5 from being found in all cases:

* For shared HDF5: Only searched if HAVE_LK_HDF5_SHARED was set
* For static HDF5: Only searched if explicitly requesting the static component

This meant that when a user did find_package(CGNS) without specifying components, the HDF5 dependency might not be resolved before cgns-targets.cmake was included, resulting in a linking error.

Creates the appropriate hdf5-static or hdf5-shared target based on how CGNS was configured and happens before include(cgns-targets.cmake), so the targets exist when needed

Fixes #851 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes HDF5 dependency resolution in `src/cgns-config.cmake.in` to prevent linking errors when using `find_package(CGNS)` without components.
> 
>   - **Behavior**:
>     - Ensures HDF5 targets (`hdf5-static` or `hdf5-shared`) are created before including `cgns-targets.cmake` in `src/cgns-config.cmake.in`.
>     - Fixes linking error when `find_package(CGNS)` is used without specifying components.
>   - **Dependency Resolution**:
>     - For shared HDF5, sets `HDF5_USE_STATIC_LIBRARIES OFF` and creates `hdf5-shared` target if not found.
>     - For static HDF5, sets `HDF5_USE_STATIC_LIBRARIES ON` and creates `hdf5-static` target if not found.
>     - Adds ZLIB and SZIP dependencies if required by HDF5.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for c91562a062a3c285373f8f253bdadca4a838510e. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->