### PR TITLE
Fix Fortran examples test script build directory creation

### DIFF
--- a/src/examples/fortran/test.sh
+++ b/src/examples/fortran/test.sh
@@ -47,6 +47,7 @@ echo "=== running tests ==="; \
 for dir in $DIRS;do
     printf "%-40s \n" "Testing $dir..."
     cd $dir
+    mkdir -p build
     x="   Program: cgwrite"
     printf "$x"
     itime=""
@@ -83,6 +84,7 @@ done
 dir=Test_cgio
 printf "%-40s \n" "Testing $dir..."
 cd $dir
+mkdir -p build
 x="   Program: cgiotest"
 printf "$x"
 if [ "$TIMING_AVAIL" = "0" ]; then


### PR DESCRIPTION
Create `build` directory before redirecting test output to ensure stdout is properly captured. Fixes #672 where test.sh failed on macOS Monterey due to a missing `build `directory.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #672 by ensuring `build` directory is created before redirecting test output in `test.sh`.
> 
>   - **Behavior**:
>     - Fixes issue #672 by creating `build` directory before redirecting test output in `test.sh`.
>     - Ensures `build` directory exists in each test directory to capture stdout properly.
>   - **Files**:
>     - Modifies `test.sh` to add `mkdir -p build` in two locations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for ef412de9eec07498043d4914a65c46892052a748. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->