### PR TITLE
Fix CG_CONFIG_GET_MAXIMUM_FILES for ADF backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
 
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -558,6 +558,17 @@ int cgio_configure (int what, void *value)
     if (what > 200) {
 #if CG_BUILD_HDF5
         ADFH_Configure(what-200, value, &ierr);
+#else
+        /* Handle HDF5-specific options when HDF5 is not available */
+        if (what == 401) {  /* CG_CONFIG_GET_MAXIMUM_FILES */
+            /* Return ADF MAXIMUM_FILES constant */
+#ifdef NEW_ID_MAPPING
+            *(int *)value = 0xfff;   /* 4095 */
+#else
+            *(int *)value = 0x3fff;  /* 16383 */
+#endif
+            ierr = CGIO_ERR_NONE;
+        }
 #endif
     }
 /* nothing here yet

--- a/src/tests/open_cgns.c
+++ b/src/tests/open_cgns.c
@@ -26,7 +26,17 @@ int main (int argc, char **argv)
 
     int maxnum_files = 99;
     if (cg_configure(CG_CONFIG_GET_MAXIMUM_FILES,  &maxnum_files)) cg_error_exit();
+#if CG_BUILD_HDF5
+    /* HDF5 backend supports 1024 files */
     if (maxnum_files != 1024) cg_error_exit();
+#else
+    /* ADF backend supports more files (4095 or 16383 depending on NEW_ID_MAPPING) */
+#ifdef NEW_ID_MAPPING
+    if (maxnum_files != 0xfff) cg_error_exit();  /* 4095 */
+#else
+    if (maxnum_files != 0x3fff) cg_error_exit(); /* 16383 */
+#endif
+#endif
 
     printf ("opening cgns file <%s> ...", filename);
     fflush (stdout);


### PR DESCRIPTION
Add support for querying maximum files in ADF-only builds. Previously returned error; now returns 4095 or 16383 based on NEW_ID_MAPPING. Also fix open_cgns test to use #if instead of #ifdef for CG_BUILD_HDF5 boolean check.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for querying maximum files in ADF-only builds and fix conditional compilation in `open_cgns.c`.
> 
>   - **Behavior**:
>     - `cgio_configure()` in `cgns_io.c` now supports `CG_CONFIG_GET_MAXIMUM_FILES` for ADF-only builds, returning 4095 or 16383 based on `NEW_ID_MAPPING`.
>     - Previously, this configuration returned an error when HDF5 was not available.
>   - **Tests**:
>     - `open_cgns.c` test updated to use `#if` instead of `#ifdef` for `CG_BUILD_HDF5` check, ensuring correct conditional compilation.
>     - Validates maximum file support for both ADF and HDF5 backends.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for 73179148ee29a9829741fe729d2273ca0ac5c2e2. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->