### PR TITLE
Fix Tcl/Tk 9.0 compatibility by properly handling Tcl_Size type

### DIFF
--- a/src/cgnstools/cgnscalc/calctcl.c
+++ b/src/cgnstools/cgnscalc/calctcl.c
@@ -8,8 +8,11 @@
 #include "calc.h"
 #include "cgnslib.h"
 
-#ifndef Tcl_Size
-# define Tcl_Size int
+/* Tcl 8.6 compatibility - Tcl_Size was introduced in Tcl 9.0 */
+#if !defined(TCL_MAJOR_VERSION) || TCL_MAJOR_VERSION < 9
+# if !defined(Tcl_Size)
+   typedef int Tcl_Size;
+# endif
 #endif
 
 static Tcl_Interp *global_interp;

--- a/src/cgnstools/cgnscalc/calctcl.c
+++ b/src/cgnstools/cgnscalc/calctcl.c
@@ -8,7 +8,7 @@
 #include "calc.h"
 #include "cgnslib.h"
 
-/* Tcl 8.6 compatibility - Tcl_Size was introduced in Tcl 9.0 */
+/* Tcl 8.x compatibility - Tcl_Size was introduced in Tcl 9.0 */
 #if !defined(TCL_MAJOR_VERSION) || TCL_MAJOR_VERSION < 9
 # if !defined(Tcl_Size)
    typedef int Tcl_Size;

--- a/src/cgnstools/cgnscalc/calcwish.c
+++ b/src/cgnstools/cgnscalc/calcwish.c
@@ -40,9 +40,7 @@ extern int Calctcl_Init (Tcl_Interp *interp);
  */
 
 int
-main(argc, argv)
-    int argc;			/* Number of command-line arguments. */
-    char **argv;		/* Values of command-line arguments. */
+main(int argc, char **argv)
 {
     /*
      * The following #if block allows you to change the AppInit
@@ -91,8 +89,7 @@ main(argc, argv)
  */
 
 int
-Tcl_AppInit(interp)
-    Tcl_Interp *interp;		/* Interpreter for application. */
+Tcl_AppInit(Tcl_Interp *interp)
 {
     if (Tcl_Init(interp) == TCL_ERROR) {
 	return TCL_ERROR;

--- a/src/cgnstools/cgnsplot/cgnstcl.c
+++ b/src/cgnstools/cgnsplot/cgnstcl.c
@@ -13,7 +13,7 @@
 #include "cgnslib.h"
 #include "hash.h"
 
-/* Tcl 8.6 compatibility - Tcl_Size was introduced in Tcl 9.0 */
+/* Tcl 8.x compatibility - Tcl_Size was introduced in Tcl 9.0 */
 #if !defined(TCL_MAJOR_VERSION) || TCL_MAJOR_VERSION < 9
 # if !defined(Tcl_Size)
    typedef int Tcl_Size;

--- a/src/cgnstools/cgnsplot/cgnstcl.c
+++ b/src/cgnstools/cgnsplot/cgnstcl.c
@@ -3824,10 +3824,11 @@ static int CGNSbounds (ClientData data, Tcl_Interp *interp, int argc, char **arg
     if (argc > 1) all = atoi(argv[1]);
     get_bounds (all, bbox);
     if (argc > 2) {
+        int i;
         if (TCL_OK != Tcl_SplitList (interp, argv[2], &n, &args))
             return TCL_ERROR;
-        for (n = 0; n < 16; n++)
-            matrix[n] = (float) atof (args[n]);
+        for (i = 0; i < 16; i++)
+            matrix[i] = (float) atof (args[i]);
         Tcl_Free ((char *)args);
         transform_bounds (matrix, bbox);
     }
@@ -3963,7 +3964,7 @@ static int OGLaxis (ClientData data, Tcl_Interp *interp, int argc, char **argv)
             if (TCL_OK != Tcl_SplitList (interp, argv[2], &nb, &args))
                 return TCL_ERROR;
             if (nb == 3) {
-                for (n = 0; n < nb; n++) {
+                for (n = 0; n < (int)nb; n++) {
                     if (sscanf (args[n], "%f %f", &bbox[n][0], &bbox[n][1]) != 2)
                         break;
                 }
@@ -5229,6 +5230,7 @@ static int OGLcutplane (ClientData data, Tcl_Interp *interp, int argc, char **ar
     mode = atoi(argv[1]);
 
     if (argc == 3) {
+        int i;
         Tcl_Size np;
         const char **args;
         if (TCL_OK != Tcl_SplitList (interp, argv[2], &np, &args))
@@ -5238,8 +5240,8 @@ static int OGLcutplane (ClientData data, Tcl_Interp *interp, int argc, char **ar
             Tcl_SetResult (interp, "invalid plane", TCL_STATIC);
             return TCL_ERROR;
         }
-        for (np = 0; np < 4; np++)
-            plane[np] = (float) atof (args[np]);
+        for (i = 0; i < 4; i++)
+            plane[i] = (float) atof (args[i]);
         Tcl_Free ((char *)args);
         init_cutplane(plane);
         find_elements();
@@ -5387,7 +5389,7 @@ static int OGLcutconfig (ClientData data, Tcl_Interp *interp, int argc, char **a
         Tcl_SetResult (interp, "invalid color", TCL_STATIC);
         return TCL_ERROR;
     }
-    for (n = 0; n < np; n++)
+    for (n = 0; n < (int)np; n++)
         cutcolor[n] = (float) atof (args[n]);
     Tcl_Free ((char *)args);
 

--- a/src/cgnstools/cgnsplot/cgnstcl.c
+++ b/src/cgnstools/cgnsplot/cgnstcl.c
@@ -13,8 +13,11 @@
 #include "cgnslib.h"
 #include "hash.h"
 
-#ifndef Tcl_Size
-# define Tcl_Size int
+/* Tcl 8.6 compatibility - Tcl_Size was introduced in Tcl 9.0 */
+#if !defined(TCL_MAJOR_VERSION) || TCL_MAJOR_VERSION < 9
+# if !defined(Tcl_Size)
+   typedef int Tcl_Size;
+# endif
 #endif
 
 #ifdef CG_BUILD_BASESCOPE

--- a/src/cgnstools/cgnsview/cgiotcl.c
+++ b/src/cgnstools/cgnsview/cgiotcl.c
@@ -13,7 +13,7 @@
 # define cgulong_t unsigned long
 #endif
 
-/* Tcl 8.6 compatibility - Tcl_Size was introduced in Tcl 9.0 */
+/* Tcl 8.x compatibility - Tcl_Size was introduced in Tcl 9.0 */
 #if !defined(TCL_MAJOR_VERSION) || TCL_MAJOR_VERSION < 9
 # if !defined(Tcl_Size)
    typedef int Tcl_Size;

--- a/src/cgnstools/cgnsview/cgiotcl.c
+++ b/src/cgnstools/cgnsview/cgiotcl.c
@@ -13,8 +13,11 @@
 # define cgulong_t unsigned long
 #endif
 
-#ifndef Tcl_Size
-# define Tcl_Size int
+/* Tcl 8.6 compatibility - Tcl_Size was introduced in Tcl 9.0 */
+#if !defined(TCL_MAJOR_VERSION) || TCL_MAJOR_VERSION < 9
+# if !defined(Tcl_Size)
+   typedef int Tcl_Size;
+# endif
 #endif
 
 /* these are the data types as used in CGIO */

--- a/src/cgnstools/cgnsview/cgiotcl.c
+++ b/src/cgnstools/cgnsview/cgiotcl.c
@@ -1526,8 +1526,8 @@ static int CGIOtype (ClientData data, Tcl_Interp *interp,
 static int CGIOdimensions (ClientData data, Tcl_Interp *interp,
     int argc, char **argv)
 {
-    int n, ndim;
-    Tcl_Size Tcl_ndim;
+    int n, ndim_int;
+    Tcl_Size ndim;
     cgsize_t dims[CGIO_MAX_DIMENSIONS];
     double node_id;
     const char **args;
@@ -1549,26 +1549,25 @@ static int CGIOdimensions (ClientData data, Tcl_Interp *interp,
     if (argc > 2) {
         if (cgio_get_data_type (cgioNum, node_id, str))
             return (get_error (interp, "cgio_get_data_type"));
-        if (TCL_OK != Tcl_SplitList (interp, argv[2], &Tcl_ndim, &args))
+        if (TCL_OK != Tcl_SplitList (interp, argv[2], &ndim, &args))
             return TCL_ERROR;
-	ndim = (int) Tcl_ndim;
         if (ndim > CGIO_MAX_DIMENSIONS) {
             Tcl_Free ((char *)args);
             Tcl_AppendResult (interp, "invalid number of dimensions", NULL);
             return TCL_ERROR;
         }
         if (ndim) {
-            for (n = 0; n < ndim; n++)
+            for (n = 0; n < (int)ndim; n++)
                 dims[n] = atoi (args[n]);
             Tcl_Free ((char *)args);
         }
-        if (cgio_set_dimensions (cgioNum, node_id, str, ndim, dims))
+        if (cgio_set_dimensions (cgioNum, node_id, str, (int)ndim, dims))
             return (get_error (interp, "cgio_set_dimensions"));
     }
-    if (cgio_get_dimensions (cgioNum, node_id, &ndim, dims))
+    if (cgio_get_dimensions (cgioNum, node_id, &ndim_int, dims))
         return (get_error (interp, "cgio_get_dimensions"));
-    if (ndim > 0) {
-        for (n = 0; n < ndim; n++) {
+    if (ndim_int > 0) {
+        for (n = 0; n < ndim_int; n++) {
             sprintf (str, "%ld", (long)dims[n]);
             Tcl_AppendElement (interp, str);
         }
@@ -1745,9 +1744,8 @@ static int CGIOread (ClientData data, Tcl_Interp *interp,
 static int CGIOwrite (ClientData data, Tcl_Interp *interp,
     int argc, char **argv)
 {
-    int n, ns;
-    int ndim;
-    Tcl_Size nv, Tcl_ndim;
+    int n, ns, ndim;
+    Tcl_Size nv, ndim_tcl;
     cgsize_t np, dims[CGIO_MAX_DIMENSIONS];
     double node_id;
     const char **args;
@@ -1792,12 +1790,12 @@ static int CGIOwrite (ClientData data, Tcl_Interp *interp,
     /* get dimensions */
 
     ndim = 0;
-    Tcl_ndim = 0;
+    ndim_tcl = 0;
     args = NULL;
     if (argc > 3 &&
-        TCL_OK != Tcl_SplitList (interp, argv[3], &Tcl_ndim, &args))
+        TCL_OK != Tcl_SplitList (interp, argv[3], &ndim_tcl, &args))
         return TCL_ERROR;
-    if (Tcl_ndim != 0) ndim = (int) Tcl_ndim;
+    if (ndim_tcl != 0) ndim = (int) ndim_tcl;
     if (ndim == 0) {
         if (cgio_set_dimensions (cgioNum, node_id, dt->name, ndim, dims))
             return (get_error (interp, "cgio_set_dimensions"));

--- a/src/cgnstools/cgnsview/cgiowish.c
+++ b/src/cgnstools/cgnsview/cgiowish.c
@@ -40,9 +40,7 @@ extern int CGIOtcl_Init (Tcl_Interp *interp);
  */
 
 int
-main(argc, argv)
-    int argc;			/* Number of command-line arguments. */
-    char **argv;		/* Values of command-line arguments. */
+main(int argc, char **argv)
 {
     /*
      * The following #if block allows you to change the AppInit
@@ -91,8 +89,7 @@ main(argc, argv)
  */
 
 int
-Tcl_AppInit(interp)
-    Tcl_Interp *interp;		/* Interpreter for application. */
+Tcl_AppInit(Tcl_Interp *interp)
 {
     if (Tcl_Init(interp) == TCL_ERROR) {
 	return TCL_ERROR;


### PR DESCRIPTION
Tcl/Tk 9.0 introduced Tcl_Size as a platform-appropriate type for sizes and counts (replacing int in many APIs). This fix ensures compatibility with both Tcl/Tk 8.6 and 9.0 by properly using Tcl_Size where required by the Tcl API while maintaining existing fallback support.

Fixes #830 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure Tcl/Tk 9.0 compatibility by using `Tcl_Size` for size/count variables in `cgnstcl.c` and `cgiotcl.c`, maintaining support for Tcl/Tk 8.6.
> 
>   - **Compatibility**:
>     - Use `Tcl_Size` instead of `int` for size/count variables in `cgnstcl.c` and `cgiotcl.c` to support Tcl/Tk 9.0.
>     - Maintain compatibility with Tcl/Tk 8.6 by using conditional compilation.
>   - **Code Changes**:
>     - Replace `int` with `Tcl_Size` for variables like `ndim` and `np` in functions such as `CGIOdimensions` and `CGIOwrite` in `cgiotcl.c`.
>     - Adjust loops and type casts to accommodate `Tcl_Size` in `cgnstcl.c` and `cgiotcl.c`.
>   - **Misc**:
>     - Fixes #830.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for 27c83ab665370fcce42e59beb1e1c754acc1e3c1. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->