### PR TITLE
Fixes Crash for test_particlef

### DIFF
--- a/src/cgns_f.F90
+++ b/src/cgns_f.F90
@@ -6701,11 +6701,11 @@ CONTAINS
     INTEGER, INTENT(IN) :: fn
     INTEGER, INTENT(IN) :: B
     INTEGER, INTENT(IN) :: P
-    CHARACTER(LEN=*) , INTENT(INOUT) :: particlename
+    CHARACTER(LEN=*) , INTENT(OUT) :: particlename
     INTEGER(CGSIZE_T), INTENT(OUT)   :: nsize
     INTEGER, INTENT(OUT) :: ier
 
-    CHARACTER(LEN=LEN_TRIM(particlename)+1,KIND=C_CHAR) :: c_particlename
+    CHARACTER(len=1, kind=C_CHAR) :: c_particlename(MAX_LEN+1)
 
     INTERFACE
        INTEGER(C_INT) FUNCTION cg_particle_read(fn, B, P, particlename, nsize) BIND(C, NAME="cg_particle_read")
@@ -6826,10 +6826,10 @@ CONTAINS
       INTEGER, INTENT(IN) :: B
       INTEGER, INTENT(IN) :: P
       INTEGER, INTENT(IN) :: C
-      CHARACTER(LEN=*) :: pcoord_name
+      CHARACTER(LEN=*), INTENT(OUT) :: pcoord_name
       INTEGER, INTENT(OUT) :: ier
 
-      CHARACTER(LEN=LEN_TRIM(pcoord_name)+1, KIND=C_CHAR) :: c_pcoord_name
+      CHARACTER(len=1, kind=C_CHAR) :: c_pcoord_name(MAX_LEN+1)
 
       INTERFACE
          INTEGER(C_INT) FUNCTION cg_particle_coord_node_read(fn, B, P, C, pcoord_name) BIND(C, NAME="cg_particle_coord_node_read")
@@ -6987,11 +6987,11 @@ CONTAINS
       INTEGER, INTENT(IN) :: P
       INTEGER, INTENT(IN) :: C
       INTEGER(cgenum_t), INTENT(OUT) :: datatype
-      CHARACTER(LEN=*)     :: coordname
+      CHARACTER(LEN=*), INTENT(OUT) :: coordname
       INTEGER, INTENT(OUT) :: ier
 
       INTEGER(C_INT) :: c_datatype
-      CHARACTER(LEN=LEN_TRIM(coordname)+1, KIND=C_CHAR) :: c_coordname
+      CHARACTER(len=1, kind=C_CHAR) :: c_coordname(MAX_LEN+1)
 
       INTERFACE
           INTEGER(C_INT) FUNCTION cg_particle_coord_info(fn, B, P, C, datatype, coordname) BIND(C, NAME="cg_particle_coord_info")
@@ -7219,10 +7219,10 @@ CONTAINS
       INTEGER, INTENT(IN) :: B
       INTEGER, INTENT(IN) :: P
       INTEGER, INTENT(IN) :: S
-      CHARACTER(LEN=*)    :: solname
+      CHARACTER(LEN=*), INTENT(OUT) :: solname
       INTEGER, INTENT(OUT) :: ier
 
-      CHARACTER(LEN=LEN_TRIM(solname)+1,KIND=C_CHAR) :: c_solname
+      CHARACTER(len=1, kind=C_CHAR) :: c_solname(MAX_LEN+1)
 
       INTERFACE
           INTEGER(C_INT) FUNCTION cg_particle_sol_info(fn, B, P, S, solname) BIND(C, NAME="cg_particle_sol_info")
@@ -7481,10 +7481,10 @@ CONTAINS
       INTEGER, INTENT(IN)  :: S
       INTEGER, INTENT(IN)  :: F
       INTEGER(cgenum_t), INTENT(OUT) :: datatype
-      CHARACTER(LEN=*),  INTENT(INOUT) :: fieldname
+      CHARACTER(LEN=*),  INTENT(OUT) :: fieldname
       INTEGER, INTENT(OUT) :: ier
 
-      CHARACTER(LEN=LEN_TRIM(fieldname)+1, KIND=C_CHAR) :: c_fieldname
+      CHARACTER(len=1, kind=C_CHAR) :: c_fieldname(MAX_LEN+1)
 
      INTERFACE
           INTEGER(C_INT) FUNCTION cg_particle_field_info(fn, B, P, S, F, datatype, fieldname) BIND(C, NAME="cg_particle_field_info")
@@ -7635,10 +7635,10 @@ CONTAINS
       INTEGER, INTENT(IN) :: fn
       INTEGER, INTENT(IN) :: B
       INTEGER, INTENT(IN) :: P
-      CHARACTER(LEN=*),  INTENT(INOUT) :: pitername
+      CHARACTER(LEN=*), INTENT(OUT) :: pitername
       INTEGER, INTENT(OUT) :: ier
 
-      CHARACTER(LEN=LEN_TRIM(pitername)+1, KIND=C_CHAR) :: c_pitername
+      CHARACTER(len=1, kind=C_CHAR) :: c_pitername(MAX_LEN+1)
 
       INTERFACE
          INTEGER(C_INT) FUNCTION cg_piter_read(fn, B, P, pitername) &

--- a/src/cgns_f.F90
+++ b/src/cgns_f.F90
@@ -7824,11 +7824,11 @@ CONTAINS
 !DEC$endif
     SUBROUTINE cg_particle_model_read_f(ModelLabel, ModelType, ier)
       IMPLICIT NONE
-      CHARACTER(LEN=*) , INTENT(INOUT) :: ModelLabel
+      CHARACTER(LEN=*), INTENT(OUT) :: ModelLabel
       INTEGER(CGENUM_T), INTENT(OUT) :: ModelType
       INTEGER, INTENT(OUT) :: ier
 
-      CHARACTER(LEN=LEN_TRIM(ModelLabel)+1,KIND=C_CHAR) :: c_ModelLabel
+      CHARACTER(len=1, kind=C_CHAR) :: c_ModelLabel(MAX_LEN+1)
 
       INTERFACE
          INTEGER(C_INT) FUNCTION cg_particle_model_read(ModelLabel, ModelType) &


### PR DESCRIPTION
Using LEN_TRIM() on output parameters may create undersized buffers when the parameter is blank:
CHARACTER(LEN=LEN_TRIM(name)+1, KIND=C_CHAR) :: c_name

Switch to using the max_len+1 instead

I couldn't get cg_write_f03 to fail, so I'm not sure about that issue yet.

Fixes #875 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes buffer size allocation in `cgns_f.F90` by replacing `LEN_TRIM()` with `MAX_LEN+1` and changes parameter intent to prevent crashes in `test_particlef`.
> 
>   - **Buffer Size Fix**:
>     - Replace `LEN_TRIM()` with `MAX_LEN+1` for buffer allocation in `cgns_f.F90` to prevent undersized buffers.
>     - Affects subroutines: `cg_particle_read_f`, `cg_particle_coord_node_read_f`, `cg_particle_coord_info_f`, `cg_particle_sol_info_f`, `cg_particle_field_info_f`, `cg_piter_read_f`, `cg_particle_model_read_f`.
>   - **Parameter Intent Change**:
>     - Change `INTENT(INOUT)` to `INTENT(OUT)` for character parameters in affected subroutines.
>   - **Issue Fix**:
>     - Fixes issue #875 related to crashes in `test_particlef`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for 7031287c2a5adb9b5cdc8e4be23aba79c487db28. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->