### PR TITLE
Addresses warning: ‘_POSIX_C_SOURCE’ redefined

### DIFF
--- a/src/adf/ADF_interface.c
+++ b/src/adf/ADF_interface.c
@@ -96,7 +96,7 @@ static char ADF_A_identification[] = "\300\250\243\251ADF Database Version A0201
 /***********************************************************************
     Includes
 ***********************************************************************/
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
   #define _POSIX_C_SOURCE 200112L
 #endif
 #include <stdio.h>

--- a/src/adf/ADF_internals.c
+++ b/src/adf/ADF_internals.c
@@ -166,7 +166,7 @@ bytes   start   end   description      range / format
 /***********************************************************************
  	Includes
 ***********************************************************************/
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
   #define _POSIX_C_SOURCE 200112L
 #endif
 #include <sys/types.h>

--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -21,7 +21,7 @@ freely, subject to the following restrictions:
 /*-------------------------------------------------------------------
  * HDF5 interface to ADF
  *-------------------------------------------------------------------*/
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
   #define _POSIX_C_SOURCE 200112L
 #endif
 #include <stdio.h>

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -23,7 +23,7 @@ freely, subject to the following restrictions:
 #define _XOPEN_SOURCE 600
 #endif
 #endif
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
   #define _POSIX_C_SOURCE 200112L
 #endif
 #include <stdio.h>

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -104,7 +104,7 @@ freely, subject to the following restrictions:
  * \defgroup ParticleModel Particle Model
  *
  */
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
   #define _POSIX_C_SOURCE 200112L
 #endif
 #include <stdio.h>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent `_POSIX_C_SOURCE` redefinition warnings by modifying preprocessor conditions in multiple source files.
> 
>   - **Preprocessor Directives**:
>     - Modify condition for defining `_POSIX_C_SOURCE` in `ADF_interface.c`, `ADF_internals.c`, `ADFH.c`, `cgns_io.c`, and `cgnslib.c`.
>     - Change `#ifndef _WIN32` to `#if !defined(_WIN32) && !defined(_POSIX_C_SOURCE)` to prevent redefinition warnings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for a3869c00cb2b0ee6302d6466c1168383c8bab50b. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->