### PR TITLE
Switch to using size_t for memory-related calculations instead of cgs…

### DIFF
--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -17512,7 +17512,7 @@ int cg_array_read(int A, void *Data)
     array = cgi_array_address(CG_MODE_READ, 0, A, "dummy", &have_dup, &ier);
     if (array==0) return ier;
 
-    for (n=0; n<array->data_dim; n++) num *= array->dim_vals[n];
+    for (n=0; n<array->data_dim; n++) num *= (size_t)array->dim_vals[n];
 
     if (array->data)
         memcpy(Data, array->data, num*size_of(array->data_type));
@@ -17555,7 +17555,7 @@ int cg_array_read_as(int A, CGNS_ENUMT(DataType_t) type, void *Data)
     array = cgi_array_address(CG_MODE_READ, 0, A, "dummy", &have_dup, &ier);
     if (array==0) return ier;
 
-    for (n=0; n<array->data_dim; n++) num *= array->dim_vals[n];
+    for (n=0; n<array->data_dim; n++) num *= (size_t)array->dim_vals[n];
 
      /* Special for Character arrays */
     if ((type == CGNS_ENUMV(Character) &&

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -17501,7 +17501,7 @@ int cg_array_read(int A, void *Data)
 {
     cgns_array *array;
     int n, ier=0;
-    cgsize_t num = 1;
+    size_t num = 1;
 
     CHECK_FILE_OPEN
 
@@ -17515,7 +17515,7 @@ int cg_array_read(int A, void *Data)
     for (n=0; n<array->data_dim; n++) num *= array->dim_vals[n];
 
     if (array->data)
-        memcpy(Data, array->data, ((size_t)num)*size_of(array->data_type));
+        memcpy(Data, array->data, num*size_of(array->data_type));
     else {
         if (cgio_read_all_data_type(cg->cgio, array->id, array->data_type, Data)) {
             cg_io_error("cgio_read_all_data_type");
@@ -17543,7 +17543,7 @@ int cg_array_read_as(int A, CGNS_ENUMT(DataType_t) type, void *Data)
 {
     cgns_array *array;
     int n, ier=0;
-    cgsize_t num = 1;
+    size_t num = 1;
     void *array_data;
 
     CHECK_FILE_OPEN
@@ -17567,7 +17567,7 @@ int cg_array_read_as(int A, CGNS_ENUMT(DataType_t) type, void *Data)
     }
     if (type==CGNS_ENUMV(Character)) {
         if (array->data)
-            memcpy(Data, array->data, ((size_t)num)*size_of(array->data_type));
+            memcpy(Data, array->data, num*size_of(array->data_type));
         else {
             if (cgio_read_all_data_type(cg->cgio, array->id, array->data_type, Data)) {
                 cg_io_error("cgio_read_all_data_type");
@@ -17581,7 +17581,7 @@ int cg_array_read_as(int A, CGNS_ENUMT(DataType_t) type, void *Data)
     if (array->data)
         array_data = array->data;
     else {
-        array_data = malloc(((size_t)num)*size_of(array->data_type));
+        array_data = malloc(num*size_of(array->data_type));
         if (array_data == NULL) {
             cgi_error("Error allocating array_data");
             return CG_ERROR;
@@ -17592,7 +17592,7 @@ int cg_array_read_as(int A, CGNS_ENUMT(DataType_t) type, void *Data)
         }
     }
 
-    ier = cgi_convert_data(num, cgi_datatype(array->data_type),
+    ier = cgi_convert_data((cgsize_t)num, cgi_datatype(array->data_type),
               array_data, type, Data);
     if (array_data != array->data) free(array_data);
 


### PR DESCRIPTION
Switch to using size_t for memory-related calculations instead of cgsize_t

Further investigation into #779
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches memory-related calculations from `cgsize_t` to `size_t` in `cgnslib.c` for better memory handling.
> 
>   - **Type Change**:
>     - Replace `cgsize_t` with `size_t` for memory calculations in `cg_array_read` and `cg_array_read_as` in `cgnslib.c`.
>     - Adjust type casting in `memcpy` and `malloc` calls to use `size_t`.
>   - **Function Updates**:
>     - Update `cgi_convert_data` call in `cg_array_read_as` to cast `num` to `cgsize_t`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for b47f5d9596681cb3a38c716bb89bdd961713d5db. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->