### PR TITLE
Patches for tests

### DIFF
--- a/src/cgnstools/calclib/calc.c
+++ b/src/cgnstools/calclib/calc.c
@@ -22,11 +22,6 @@
 #include "cgns_io.h"
 #endif
 
-#ifndef CGNSTYPES_H
-# define cgsize_t  int
-# define cglong_t  long
-# define cgulong_t unsigned long
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/cgnstools/cgnsview/cgiotcl.c
+++ b/src/cgnstools/cgnsview/cgiotcl.c
@@ -7,11 +7,6 @@
 #include "cgns_io.h"
 #include "cgnslib.h" /* only needed for CGNS_VERSION */
 
-#ifndef CGNSTYPES_H
-# define cgsize_t  int
-# define cglong_t  long
-# define cgulong_t unsigned long
-#endif
 
 /* Tcl 8.x compatibility - Tcl_Size was introduced in Tcl 9.0 */
 #if !defined(TCL_MAJOR_VERSION) || TCL_MAJOR_VERSION < 9

--- a/src/cgnstools/utilities/cgnsImport.h
+++ b/src/cgnstools/utilities/cgnsImport.h
@@ -5,9 +5,6 @@
 
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/cgnstools/utilities/cgnsutil.h
+++ b/src/cgnstools/utilities/cgnsutil.h
@@ -7,10 +7,6 @@
 
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-# define CG_MAX_INT32 0x7FFFFFFF
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/cgread.F90
+++ b/src/tests/cgread.F90
@@ -8,7 +8,7 @@
 #ifdef WINNT
 	include 'cgnswin_f.h'
 #endif
-	include 'cgnslib_f.h'
+	use CGNS
 
 	integer Ndim, Nglobal
 	parameter (Ndim = 3)

--- a/src/tests/cgsubreg.F90
+++ b/src/tests/cgsubreg.F90
@@ -4,7 +4,7 @@
 #ifdef WINNT
       include 'cgnswin_f.h'
 #endif
-      include 'cgnslib_f.h'
+      use CGNS
 
       cgsize_t ierr, cgfile, cgbase, cgzone, cgcoord
       cgsize_t csub, nsub, dim

--- a/src/tests/cgwrite.F90
+++ b/src/tests/cgwrite.F90
@@ -10,7 +10,7 @@
 #ifdef WINNT
 	include 'cgnswin_f.h'
 #endif
-	include 'cgnslib_f.h'
+	use CGNS
 
 	integer Ndim
 	parameter (Ndim = 3)

--- a/src/tests/cgwrite_f03.F90
+++ b/src/tests/cgwrite_f03.F90
@@ -46,6 +46,8 @@ PROGRAM write_cgns_1
   USE CGNS
   USE ISO_C_BINDING
   USE cgns_write_test
+  USE ISO_FORTRAN_ENV, ONLY : ERROR_UNIT
+
   IMPLICIT NONE
 
   ! author: Diane Poirier (diane@icemcfd.com)
@@ -328,7 +330,10 @@ PROGRAM write_cgns_1
   f_ptr = C_LOC(maxnum_files)
   CALL cg_configure_f(CG_CONFIG_GET_MAXIMUM_FILES, f_ptr, ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
-  IF (maxnum_files .NE. 1024) CALL cg_error_exit_f
+  IF (maxnum_files .NE. 1024) THEN
+    WRITE(ERROR_UNIT, *) "ERROR: Unexpected CG_CONFIG_GET_MAXIMUM_FILES result"
+    CALL cg_error_exit_f
+  ENDIF
 
   ! enable committing memory to disk
   value_f = 1

--- a/src/tests/cgzconn.F90
+++ b/src/tests/cgzconn.F90
@@ -4,7 +4,7 @@
 #ifdef WINNT
       include 'cgnswin_f.h'
 #endif
-      include 'cgnslib_f.h'
+      use CGNS
 
       cgsize_t ierr, cgfile, cgbase, cgzone, cgcoord
       cgsize_t cgz1, cgz2, cgconn, nzconn, nconn, n1to1

--- a/src/tests/test64f.F90
+++ b/src/tests/test64f.F90
@@ -3,7 +3,7 @@
 #ifdef WINNT
       include 'cgnswin_f.h'
 #endif
-      include 'cgnslib_f.h'
+      use CGNS
 
       integer*8 nnodes,nelems
       integer dotest

--- a/src/tests/test64f_f03.F90
+++ b/src/tests/test64f_f03.F90
@@ -3,7 +3,7 @@
 #ifdef WINNT
       include 'cgnswin_f.h'
 #endif
-      include 'cgnslib_f.h'
+      use CGNS
 
       integer*8 nnodes,nelems
       integer dotest

--- a/src/tests/test_back_comp.c
+++ b/src/tests/test_back_comp.c
@@ -433,6 +433,7 @@ int main()
       cg_error_exit();
     if ( ! compareValuesChr(state,"ReferenceQuantities"))
       cg_error_exit();
+    cg_free(state);
 
     printf("\nReferenceState = %s\n",state);
 
@@ -503,6 +504,7 @@ int main()
         cg_error_exit();
 
       printf("\nThe descriptor is:\n\n%s\n",text);
+      cg_free(text);
     }
 
     /* ---------------------------------- read_convergence*/

--- a/src/tests/test_bbox.c
+++ b/src/tests/test_bbox.c
@@ -9,9 +9,6 @@
 #endif
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/test_complex.c
+++ b/src/tests/test_complex.c
@@ -22,9 +22,6 @@
 #endif
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/test_exts.c
+++ b/src/tests/test_exts.c
@@ -9,9 +9,6 @@
 #endif
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/test_goto.c
+++ b/src/tests/test_goto.c
@@ -9,9 +9,6 @@
 #endif
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/test_partial.c
+++ b/src/tests/test_partial.c
@@ -9,9 +9,6 @@
 #endif
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/utils.h
+++ b/src/tests/utils.h
@@ -6,9 +6,6 @@
 #include <string.h>
 
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/utils.h
+++ b/src/tests/utils.h
@@ -98,8 +98,8 @@ int write_test_header(char *title_header, int len)
 
   width = TAB_SPACE+10;
 
-  char *title_centered = (char*)malloc(4*width+1*sizeof(char));
-  char *str = (char*)malloc(2*width+2*sizeof(char));
+  char *title_centered = (char*)malloc((4*width+1)*sizeof(char));
+  char *str = (char*)malloc((2*width+2)*sizeof(char));
 
   memcpy(str,title_header,len);
   str[len] = '\0';

--- a/src/tests/write_rind.c
+++ b/src/tests/write_rind.c
@@ -10,9 +10,6 @@
 #endif
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/write_test.c
+++ b/src/tests/write_test.c
@@ -10,9 +10,6 @@
 #endif
 #include "cgnslib.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
 #ifndef CGNS_ENUMT
 # define CGNS_ENUMT(e) e
 # define CGNS_ENUMV(e) e

--- a/src/tests/write_test.c
+++ b/src/tests/write_test.c
@@ -37,7 +37,6 @@
 int CellDim = 3, PhyDim = 3;
 
 int cgfile, cgbase, cgzone;
-int CellDim, PhyDim;
 cgsize_t size[9];
 
 #define NUM_SIDE 5

--- a/src/tools/cgnsdiff.c
+++ b/src/tools/cgnsdiff.c
@@ -7,9 +7,7 @@
 #include "cgns_io.h"
 #include "getargs.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
+#include "cgnstypes.h"
 
 static int nocase = 0;
 static int nospace = 0;

--- a/src/tools/cgnslist.c
+++ b/src/tools/cgnslist.c
@@ -8,9 +8,7 @@
 #include "cgns_io.h"
 #include "getargs.h"
 
-#ifndef CGNSTYPES_H
-# define cgsize_t int
-#endif
+#include "cgnstypes.h"
 
 #if CG_HAVE_STAT64_STRUCT
 #ifdef _WIN32


### PR DESCRIPTION
It takes care of #879.
Some other small fixes too.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant type definitions and improve memory management in test and tool files.
> 
>   - **Type Definitions**:
>     - Remove redundant type definitions for `cgsize_t`, `cglong_t`, and `cgulong_t` in `calc.c`, `cgiotcl.c`, `cgnsImport.h`, `cgnsutil.h`, `test_bbox.c`, `test_complex.c`, `test_exts.c`, `test_goto.c`, `test_partial.c`, `utils.h`, `write_rind.c`, and `write_test.c`.
>     - Include `cgnstypes.h` in `cgnsdiff.c` and `cgnslist.c`.
>   - **Fortran Files**:
>     - Replace `include 'cgnslib_f.h'` with `use CGNS` in `cgread.F90`, `cgsubreg.F90`, `cgwrite.F90`, `cgwrite_f03.F90`, `cgzconn.F90`, `test64f.F90`, and `test64f_f03.F90`.
>   - **Memory Management**:
>     - Add `cg_free()` calls in `test_back_comp.c` to free memory allocated for `state` and `text`.
>   - **Miscellaneous**:
>     - Add `use ISO_FORTRAN_ENV, ONLY : ERROR_UNIT` in `cgwrite_f03.F90` for error handling.
>     - Add error message in `cgwrite_f03.F90` for unexpected `CG_CONFIG_GET_MAXIMUM_FILES` result.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for d5c32686ccab7737842178c61a9c70974995c5e1. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->