### PR TITLE
cg_configure Fortran to C interface

### DIFF
--- a/src/cg_ftoc.c
+++ b/src/cg_ftoc.c
@@ -119,51 +119,54 @@ static void string_2_F_string(char *c_string, char *string,
 
 /*-----------------------------------------------------------------------*/
 
-CGNSDLL void cg_configure_c_ptr(cgint_f *what, void *value, cgint_f *ier)
+CGNSDLL int cg_configure_c_ptr(int what, void *value)
 {
+  int ier;
   /* CHARACTERS */
-  if( (int)*what == CG_CONFIG_SET_PATH ||
-      (int)*what == CG_CONFIG_ADD_PATH) {
-    *ier = (cgint_f)cg_configure((int)*what, value);
-  } else if( (int)*what == CG_CONFIG_ERROR) {
-    *ier = (cgint_f)CG_ERROR;
+  if( what == CG_CONFIG_SET_PATH ||
+      what == CG_CONFIG_ADD_PATH) {
+    ier = cg_configure(what, value);
+  } else if( what == CG_CONFIG_ERROR) {
+    ier = CG_ERROR;
 
   /* MPI COMMUNICATOR */
 #if CG_BUILD_PARALLEL
-  } else if( (int)*what == CG_CONFIG_HDF5_MPI_COMM ) {
-    MPI_Fint F_comm = *(MPI_Fint *)value;
+  } else if( what == CG_CONFIG_HDF5_MPI_COMM ) {
+    MPI_Fint F_comm = (MPI_Fint)value;
     MPI_Comm C_comm = MPI_Comm_f2c(F_comm);
-    *ier = (cgint_f)cg_configure((int)*what, &C_comm);
+    ier = cg_configure(what, &C_comm);
 #endif
 
   /* RIND */
-  } else if( (int)*what == CG_CONFIG_RIND_INDEX) {
-    if(*(int*)value == 0) {
-      *ier = (cgint_f)cg_configure((int)*what, CG_CONFIG_RIND_ZERO);
-    } else if(*(int*)value == 1) {
-      *ier = (cgint_f)cg_configure((int)*what, CG_CONFIG_RIND_CORE);
+  } else if( what == CG_CONFIG_RIND_INDEX) {
+    if(*(int *)value == 0) {
+      ier = cg_configure(what, CG_CONFIG_RIND_ZERO);
+    } else if(*(int *)value == 1) {
+      ier = cg_configure(what, CG_CONFIG_RIND_CORE);
     } else {
-      *ier = (cgint_f)CG_ERROR;
-      return;
+      ier = CG_ERROR;
+      return ier;
     }
   /* get value */
-  } else if( (int)*what == CG_CONFIG_GET_MAXIMUM_FILES) {
-    *ier = (cgint_f)cg_configure((int)*what, value);
+  } else if( what == CG_CONFIG_GET_MAXIMUM_FILES) {
+    ier = cg_configure(what, value);
 
   /* EVERYTHING ELSE */
   } else {
-    *ier = (cgint_f)cg_configure((int)*what, (void *)(*(size_t *)value));
+    ier = cg_configure(what, (void *)(*(size_t *)value));
   }
+  return ier;
 }
 
-CGNSDLL void cg_configure_c_funptr(cgint_f *what, void *value, cgint_f *ier)
+CGNSDLL int cg_configure_c_funptr(int what, void *value)
 {
-  if ( (int)*what == CG_CONFIG_ERROR ) {
-      *ier = (cgint_f)cg_configure((int)*what, value);
+  int ier;
+  if ( what == CG_CONFIG_ERROR ) {
+      ier = cg_configure(what, value);
   } else {
-      *ier = (cgint_f)CG_ERROR;
+      ier = CG_ERROR;
   }
-  return;
+  return ier;
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\

--- a/src/cg_ftoc.c
+++ b/src/cg_ftoc.c
@@ -149,7 +149,7 @@ CGNSDLL int cg_configure_c_ptr(int what, void *value)
     }
   /* get value */
   } else if( what == CG_CONFIG_GET_MAXIMUM_FILES) {
-    ier = cg_configure(what, value);
+    ier = cg_configure(what, (void *)((int *)value));
 
   /* EVERYTHING ELSE */
   } else {

--- a/src/cgns_f.F90
+++ b/src/cgns_f.F90
@@ -6618,23 +6618,22 @@ CONTAINS
 !DEC$ATTRIBUTES DLLEXPORT :: cg_configure_ptr
 !DEC$endif
   SUBROUTINE cg_configure_ptr(what, value, ier)
-    USE ISO_C_BINDING, ONLY : C_PTR
+    USE ISO_C_BINDING, ONLY : C_PTR, C_INT
     IMPLICIT NONE
     INTEGER, INTENT(IN) :: what
     TYPE(C_PTR), VALUE :: value
     INTEGER, INTENT(OUT) :: ier
 
     INTERFACE
-       SUBROUTINE cg_configure_c_ptr(what, value, ier) BIND(C, name="cg_configure_c_ptr")
-         IMPORT :: C_PTR
+      INTEGER(C_INT) FUNCTION cg_configure_c_ptr(what, value) BIND(C, name="cg_configure_c_ptr")
+         IMPORT :: C_PTR, C_INT
          IMPLICIT NONE
-         INTEGER :: what
+         INTEGER(C_INT), VALUE :: what
          TYPE(C_PTR), VALUE :: value
-         INTEGER :: ier
-       END SUBROUTINE cg_configure_c_ptr
+      END FUNCTION cg_configure_c_ptr
     END INTERFACE
 
-    CALL cg_configure_c_ptr(what, value, ier)
+    ier = INT(cg_configure_c_ptr(INT(what, C_INT), value))
 
   END SUBROUTINE cg_configure_ptr
 
@@ -6642,23 +6641,22 @@ CONTAINS
 !DEC$ATTRIBUTES DLLEXPORT :: cg_configure_funptr
 !DEC$endif
   SUBROUTINE cg_configure_funptr(what, value, ier)
-    USE ISO_C_BINDING, ONLY : C_FUNPTR
+    USE ISO_C_BINDING, ONLY : C_FUNPTR, C_INT
     IMPLICIT NONE
     INTEGER, INTENT(IN) :: what
     TYPE(C_FUNPTR), VALUE :: value
     INTEGER, INTENT(OUT) :: ier
 
     INTERFACE
-      SUBROUTINE cg_configure_c_funptr(what, value, ier) BIND(C, name="cg_configure_c_funptr")
-        IMPORT :: C_FUNPTR
+      INTEGER(C_INT) FUNCTION cg_configure_c_funptr(what, value) BIND(C, name="cg_configure_c_funptr")
+        IMPORT :: C_FUNPTR, C_INT
         IMPLICIT NONE
-        INTEGER :: what
+        INTEGER(C_INT), VALUE :: what
         TYPE(C_FUNPTR), VALUE :: value
-        INTEGER :: ier
-      END SUBROUTINE cg_configure_c_funptr
+      END FUNCTION cg_configure_c_funptr
     END INTERFACE
 
-    CALL cg_configure_c_funptr(what, value, ier)
+    ier = INT(cg_configure_c_funptr(INT(what, C_INT), value))
 
   END SUBROUTINE cg_configure_funptr
 

--- a/src/tests/cgwrite_f03.F90
+++ b/src/tests/cgwrite_f03.F90
@@ -80,7 +80,7 @@ PROGRAM write_cgns_1
   CHARACTER(LEN=32) coordname(Ndim)
   CHARACTER(LEN=32) donorname
 
-  INTEGER, TARGET :: value_f
+  INTEGER(C_INT), TARGET :: value_f
   INTEGER(C_INT), TARGET :: maxnum_files
   INTEGER(C_SIZE_T), TARGET :: value_size_t_f
   CHARACTER(LEN=32), TARGET :: path
@@ -322,8 +322,8 @@ PROGRAM write_cgns_1
   ! **************************
   ! Test cg_configure options
   ! **************************
-  value_f = 1
-  CALL cg_configure_f(CG_CONFIG_HDF5_DISKLESS, C_LOC(value_f), ier)
+  value_size_t_f = INT(1, C_SIZE_T)
+  CALL cg_configure_f(CG_CONFIG_HDF5_DISKLESS, C_LOC(value_size_t_f), ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
 
   maxnum_files = 1
@@ -336,8 +336,8 @@ PROGRAM write_cgns_1
   ENDIF
 
   ! enable committing memory to disk
-  value_f = 1
-  CALL cg_configure_f(CG_CONFIG_HDF5_DISKLESS_WRITE, C_LOC(value_f), ier)
+  value_size_t_f = INT(1, C_SIZE_T)
+  CALL cg_configure_f(CG_CONFIG_HDF5_DISKLESS_WRITE, C_LOC(value_size_t_f), ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
   value_size_t_f = INT(20*1024*1024,C_SIZE_T)
   CALL cg_configure_f(CG_CONFIG_HDF5_DISKLESS_INCR, C_LOC(value_size_t_f), ier)
@@ -353,26 +353,26 @@ PROGRAM write_cgns_1
   CALL cg_close_f(cg, ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
 
-  value_f = 0
-  CALL cg_configure_f(CG_CONFIG_HDF5_DISKLESS, C_LOC(value_f), ier)
+  value_size_t_f = INT(0, C_SIZE_T)
+  CALL cg_configure_f(CG_CONFIG_HDF5_DISKLESS, C_LOC(value_size_t_f), ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
 
-  value_f = CG_FILE_ADF2
-  value_f = CG_FILE_ADF
-  f_ptr = C_LOC(value_f)
+  value_size_t_f = CG_FILE_ADF2
+  value_size_t_f = CG_FILE_ADF
+  f_ptr = C_LOC(value_size_t_f)
   CALL cg_configure_f(CG_CONFIG_FILE_TYPE, f_ptr, ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
-  value_f = CG_FILE_HDF5
-  CALL cg_configure_f(CG_CONFIG_FILE_TYPE, C_LOC(value_f), ier)
+  value_size_t_f = CG_FILE_HDF5
+  CALL cg_configure_f(CG_CONFIG_FILE_TYPE, C_LOC(value_size_t_f), ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
-  value_f = -1
-  CALL cg_configure_f(CG_CONFIG_HDF5_COMPRESS, C_LOC(value_f), ier)
+  value_size_t_f = -1
+  CALL cg_configure_f(CG_CONFIG_HDF5_COMPRESS, C_LOC(value_size_t_f), ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
-  value_f = -1
-  CALL cg_configure_f(CG_CONFIG_COMPRESS, C_LOC(value_f), ier)
+  value_size_t_f = -1
+  CALL cg_configure_f(CG_CONFIG_COMPRESS, C_LOC(value_size_t_f), ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
-  value_f =  CG_CONFIG_RIND_ZERO
 
+  value_f =  CG_CONFIG_RIND_ZERO
   CALL cg_configure_f(CG_CONFIG_RIND_INDEX, C_LOC(value_f), ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
   value_f = CG_CONFIG_RIND_CORE
@@ -390,8 +390,8 @@ PROGRAM write_cgns_1
   CALL cg_configure_f(CG_CONFIG_SET_PATH, C_LOC(path(1:1)), ier)
   IF (ier .EQ. ERROR) CALL cg_error_exit_f
 
-  value_f = 100 ! Trigger an error
-  CALL cg_configure_f(CG_CONFIG_FILE_TYPE, C_LOC(value_f), ier)
+  value_size_t_f = 100 ! Trigger an error
+  CALL cg_configure_f(CG_CONFIG_FILE_TYPE, C_LOC(value_size_t_f), ier)
   IF (ier .NE. ERROR) CALL cg_error_exit_f
 
 ! testing using callbacks with CG_CONFIGURE


### PR DESCRIPTION
- let compiler handle the what parameter transfer to  try to fix #875
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor Fortran to C interface for `cg_configure` to let the compiler handle parameter transfers, updating interface functions and test cases.
> 
>   - **Interface Changes**:
>     - Refactor `cg_configure_c_ptr` and `cg_configure_c_funptr` in `cg_ftoc.c` to let the compiler handle parameter transfers.
>     - Change return type from `void` to `int` for error handling.
>   - **Fortran Bindings**:
>     - Update `cg_configure_ptr` and `cg_configure_funptr` in `cgns_f.F90` to use `INTEGER(C_INT) FUNCTION` instead of `SUBROUTINE`.
>     - Use `INT()` for type conversion in `cg_configure_ptr` and `cg_configure_funptr`.
>   - **Tests**:
>     - Modify `cgwrite_f03.F90` to use `INTEGER(C_INT)` and `INTEGER(C_SIZE_T)` for `value_f` and `value_size_t_f`.
>     - Update test cases to reflect changes in parameter handling and type conversions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for a969344d0da2f2d94f641e62583d25bde2157465. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->