### PR TITLE
fix wrong free memory

### DIFF
--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -17257,7 +17257,7 @@ void cgi_free_particle(cgns_pzone *pzone)
    }
    if (pzone->nintegrals) {
        for (n=0; n<pzone->nintegrals; n++)
-            cgi_free_integral(pzone->integral);
+            cgi_free_integral(&pzone->integral[n]);
        CGNS_FREE(pzone->integral);
    }
    if (pzone->state) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes incorrect memory free in `cgi_free_particle` in `cgns_internals.c` by correctly freeing each element in `pzone->integral` array.
> 
>   - **Bug Fix**:
>     - Fixes incorrect memory free in `cgi_free_particle` in `cgns_internals.c`.
>     - Changes `cgi_free_integral(pzone->integral)` to `cgi_free_integral(&pzone->integral[n])` to correctly free each element in `pzone->integral` array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for 8fd7f8e677b911d193a786718e5f57888f899eae. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->