### PR TITLE
Macro CGNS_FREE should not end with semicolon for consistency

### DIFF
--- a/src/cgns_header.h
+++ b/src/cgns_header.h
@@ -114,7 +114,7 @@ typedef int cgint3_t[3];
 
 #define CGNS_NEW(type,size)  (type *)cgi_malloc((size_t)(size),sizeof(type))
 #define CGNS_RENEW(type,size,old) (type *)cgi_realloc(old,(size_t)(size)*sizeof(type))
-#define CGNS_FREE(data) free(data);
+#define CGNS_FREE(data) free(data)
 
 #define INVALID_ENUM(E,EMAX) ((int)(E)<0 || (int)(E)>=(EMAX))
 

--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -17279,7 +17279,7 @@ void cgi_free_particle(cgns_pzone *pzone)
    if (pzone->nuser_data) {
       for (n=0; n<pzone->nuser_data; n++)
            cgi_free_user_data(&pzone->user_data[n]);
-      CGNS_FREE(pzone->user_data)
+      CGNS_FREE(pzone->user_data);
    }
 }
 

--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -295,7 +295,7 @@ int cgi_read_user_data_from_list(int in_link, _childnode_t* nodelist, int nnodes
     if (error) { \
         for (m = 0; m < NofBaseLabel; m++) { \
             if (childbylabel[m] == NULL) continue; \
-            CGNS_FREE(childbylabel[m]) \
+            CGNS_FREE(childbylabel[m]); \
         } \
         return CG_ERROR; \
     }
@@ -491,7 +491,7 @@ int cgi_read_base(cgns_base *base)
 
     for (m = 0; m < NofBaseLabel; m++) {
         if (childbylabel[m] == NULL) continue;
-        CGNS_FREE(childbylabel[m])
+        CGNS_FREE(childbylabel[m]);
     }
     /* read zones */
     for (n = 0; n < base->nzones; n++) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove semicolon from `CGNS_FREE` macro definition and adjust its usage in `cgns_internals.c` for consistency.
> 
>   - **Macro Definition**:
>     - Remove semicolon from `CGNS_FREE` macro in `cgns_header.h` for consistency.
>   - **Usage Adjustments**:
>     - Add semicolons after `CGNS_FREE` calls in `cgi_read_user_data_from_list()`, `cgi_read_base()`, and `cgi_free_particle()` in `cgns_internals.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for 823f394fa29ec07390174f607126b146a1e09a3a. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->