### PR TITLE
Remove warning for && right side effect

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -348,8 +348,11 @@ static herr_t print_H5_error(int n, H5E_error2_t *desc, void *data)
 {
   const char *p;
 
-  if ((p = strrchr(desc->file_name, '/')) == NULL &&
-      (p = strrchr(desc->file_name, '\\')) == NULL)
+  p = strrchr(desc->file_name, '/');
+  if (p == NULL) {
+    p = strrchr(desc->file_name, '\\');
+  }
+  if (p == NULL)
     p = desc->file_name;
   else
     p++;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `print_H5_error()` in `ADFH.c` to remove logical AND with side effects by splitting into separate statements.
> 
>   - **Refactoring**:
>     - Refactor `if` condition in `print_H5_error()` in `ADFH.c` to remove logical AND with side effects by splitting into separate statements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for b6bb1f7e9ddda9f8c5cc654ea501471951e93384. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->