### PR TITLE
updated HDF5 installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The CFD General Notation System (CGNS) provides a standard for recording and rec
 
 1. Install HDF5 on your system.
   
-   - HDF5 can use the standard GNU autotools, so `./configure`, `make`, `sudo make install` should install HDF5 without problems on most systems.
+   - Either use a package manager or install it from source with CMake.
 2. Unpack the tar ball containing the source code into some directory.
 3. Create a new directory in which to build the library.
 4. Use `cmake` to initialize the build tree.
@@ -55,7 +55,7 @@ The CFD General Notation System (CGNS) provides a standard for recording and rec
 ### Installation Instructions using `make`
 
 1. Install HDF5 on your system.
-   - HDF5 can use the standard GNU autotools, so `./configure`, `make`, `sudo make install` should install HDF5 without problems on most systems.
+   - Either use a package manager or install it from source with CMake.
 2. Typically the standard `./configure`, `make`, `make install` will suffice.  
 3. Sample scripts for building parallel CGNS can be found in `src/SampleScripts`.
 


### PR DESCRIPTION
autotools have been deprecated with recent HDF5 versions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated HDF5 installation instructions in `README.md` to replace deprecated autotools with package manager or CMake.
> 
>   - **Installation Instructions**:
>     - Updated HDF5 installation instructions in `README.md` to replace deprecated autotools with package manager or CMake.
>     - Affects both `cmake` and `make` installation sections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for 8ed7255b34e7e38ea784abfc337284e9abbdd3a4. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->