### PR TITLE
Remove global hdf5_access reset

### DIFF
--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -2292,15 +2292,16 @@ void ADFH_Database_Open(const char   *name,
 #endif
 
   /* open the file */
-  access_mode = CGIO_NATIVE_MODE;
+  /* Convert format string to enum for internal use (Issue #836) */
+  access_mode = (0 == strcmp(fmt, "PARALLEL")) ? CGIO_PARALLEL_MODE : CGIO_NATIVE_MODE;
+
 #if CG_BUILD_PARALLEL
   int flag = 0;
   /* check if we are actually running a parallel program */
   MPI_Initialized(&flag);
   if(flag) {
     /* Set the access property list to use MPI */
-    /* Use enum instead of string comparison for efficiency (Issue #836) */
-    if (ctx_cgio.hdf5_access_mode == CGIO_PARALLEL_MODE) {
+    if (access_mode == CGIO_PARALLEL_MODE) {
 
       if(!ctx_cgio.pcg_mpi_info) ctx_cgio.pcg_mpi_info = MPI_INFO_NULL;
 #if HDF5_HAVE_COLL_METADATA  

--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -2299,7 +2299,8 @@ void ADFH_Database_Open(const char   *name,
   MPI_Initialized(&flag);
   if(flag) {
     /* Set the access property list to use MPI */
-    if (0 == strcmp(fmt, "PARALLEL")) {
+    /* Use enum instead of string comparison for efficiency (Issue #836) */
+    if (ctx_cgio.hdf5_access_mode == CGIO_PARALLEL_MODE) {
 
       if(!ctx_cgio.pcg_mpi_info) ctx_cgio.pcg_mpi_info = MPI_INFO_NULL;
 #if HDF5_HAVE_COLL_METADATA  

--- a/src/cgio_internal_type.h
+++ b/src/cgio_internal_type.h
@@ -1,6 +1,12 @@
+typedef enum {
+  CGIO_NATIVE_MODE = 0,
+  CGIO_PARALLEL_MODE = 1
+} access_mode_t;
+
 typedef struct _cgns_io_ctx_t {
     /* Flag indicating if HDF5 file accesses is PARALLEL or NATIVE */
-    char hdf5_access[64];
+    char hdf5_access[64];  /* Keep for API compatibility */
+    access_mode_t hdf5_access_mode;  /* Internal enum, avoid string comparisons */
 #if CG_BUILD_PARALLEL
     /* MPI-2 info object */
     MPI_Comm pcg_mpi_comm;
@@ -12,8 +18,3 @@ typedef struct _cgns_io_ctx_t {
     hid_t default_pio_mode;
 #endif
 } cgns_io_ctx_t;
-
-typedef enum {
-  CGIO_NATIVE_MODE = 0,
-  CGIO_PARALLEL_MODE = 1
-} access_mode_t;

--- a/src/cgio_internal_type.h
+++ b/src/cgio_internal_type.h
@@ -1,3 +1,6 @@
+#ifndef CGIO_INTERNAL_TYPE_H
+#define CGIO_INTERNAL_TYPE_H
+
 typedef enum {
   CGIO_NATIVE_MODE = 0,
   CGIO_PARALLEL_MODE = 1
@@ -17,3 +20,5 @@ typedef struct _cgns_io_ctx_t {
     hid_t default_pio_mode;
 #endif
 } cgns_io_ctx_t;
+
+#endif /* CGIO_INTERNAL_TYPE_H */

--- a/src/cgio_internal_type.h
+++ b/src/cgio_internal_type.h
@@ -5,8 +5,7 @@ typedef enum {
 
 typedef struct _cgns_io_ctx_t {
     /* Flag indicating if HDF5 file accesses is PARALLEL or NATIVE */
-    char hdf5_access[64];  /* Keep for API compatibility */
-    access_mode_t hdf5_access_mode;  /* Internal enum, avoid string comparisons */
+    access_mode_t hdf5_access_mode;
 #if CG_BUILD_PARALLEL
     /* MPI-2 info object */
     MPI_Comm pcg_mpi_comm;

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -60,14 +60,16 @@ freely, subject to the following restrictions:
 #endif
 
 #if CG_BUILD_HDF5
-cgns_io_ctx_t ctx_cgio = { .hdf5_access = "NATIVE",
+cgns_io_ctx_t ctx_cgio = {
+    .hdf5_access = "NATIVE",
+    .hdf5_access_mode = CGIO_NATIVE_MODE,
 #if CG_BUILD_PARALLEL
-.pcg_mpi_comm = MPI_COMM_NULL, 
-.pcg_mpi_comm_size=1,
-.pcg_mpi_comm_rank=0,
-.pcg_mpi_initialized=0,
-.pcg_mpi_info=MPI_INFO_NULL,
-.default_pio_mode=H5FD_MPIO_COLLECTIVE
+    .pcg_mpi_comm = MPI_COMM_NULL,
+    .pcg_mpi_comm_size=1,
+    .pcg_mpi_comm_rank=0,
+    .pcg_mpi_initialized=0,
+    .pcg_mpi_info=MPI_INFO_NULL,
+    .default_pio_mode=H5FD_MPIO_COLLECTIVE
 #endif
 };
 #endif
@@ -90,6 +92,12 @@ typedef struct {
     int mode;
     double rootid;
     int access_mode;
+    int storage_type;  /* HDF5 storage type for this file */
+#if CG_BUILD_PARALLEL
+    MPI_Comm mpi_comm;
+    MPI_Info mpi_info;
+    hid_t pio_mode;
+#endif
 } cgns_io;
 
 static int num_open = 0;
@@ -152,6 +160,26 @@ static cgns_io *get_cgnsio (int cgio_num, int write)
     last_type = iolist[cgio_num].type;
     last_err = CGIO_ERR_NONE;
     return &iolist[cgio_num];
+}
+
+/*---------------------------------------------------------*/
+
+/* Get per-file storage type */
+static int get_file_storage_type(int cgio_num)
+{
+    cgns_io *cgio = get_cgnsio(cgio_num, 0);
+    if (cgio == NULL) return HDF5storage_type; /* fallback to global */
+    return cgio->storage_type;
+}
+
+/*---------------------------------------------------------*/
+
+/* Get per-file access mode */
+static int get_file_access_mode(int cgio_num)
+{
+    cgns_io *cgio = get_cgnsio(cgio_num, 0);
+    if (cgio == NULL) return CGIO_NATIVE_MODE;
+    return cgio->access_mode;
 }
 
 /*---------------------------------------------------------*/
@@ -845,15 +873,22 @@ int cgio_open_file (const char *filename, int file_mode,
     iolist[n].type = file_type;
     iolist[n].mode = file_mode;
     iolist[n].rootid = rootid;
-/* keep track of file parallel/native opening mode */
+
+    /* Copy global configuration to per-file settings */
+    iolist[n].storage_type = HDF5storage_type;
     iolist[n].access_mode = CGIO_NATIVE_MODE;
 #if CG_BUILD_HDF5
     if (file_type == CGIO_FILE_HDF5) {
-        if (strcmp(ctx_cgio.hdf5_access, "PARALLEL") == 0){
-          iolist[n].access_mode = CGIO_PARALLEL_MODE;
-        }
+        /* Use enum instead of string comparison for efficiency */
+        iolist[n].access_mode = ctx_cgio.hdf5_access_mode;
     }
 #endif
+#if CG_BUILD_PARALLEL
+    iolist[n].mpi_comm = ctx_cgio.pcg_mpi_comm;
+    iolist[n].mpi_info = ctx_cgio.pcg_mpi_info;
+    iolist[n].pio_mode = ctx_cgio.default_pio_mode;
+#endif
+
     *cgio_num = n + 1;
     num_open++;
 
@@ -1185,7 +1220,7 @@ int cgio_new_node (int cgio_num, double pid, const char *name,
       ADFH_Set_Label(*id, label, &ierr);
       if (ierr > 0) return set_error(ierr);
       if (data_type != NULL && strcmp(data_type, "MT")) {
-        ADFH_Put_Dimension_Information(*id, data_type, ndims, dims, HDF5storage_type, &ierr);
+        ADFH_Put_Dimension_Information(*id, data_type, ndims, dims, cgio->storage_type, &ierr);
         if (ierr > 0) return set_error(ierr);
         if (data != NULL) {
           ADFH_Write_All_Data(*id, NULL, (const char *)data, &ierr);
@@ -1345,7 +1380,7 @@ int cgio_copy_node (int cgio_num_inp, double id_inp,
         ADFH_Set_Label(id_out, label, &ierr);
         if (ierr <= 0) {
             ADFH_Put_Dimension_Information(id_out, data_type, ndims,
-                                           dims, HDF5storage_type, &ierr);
+                                           dims, output->storage_type, &ierr);
             if (ierr <= 0 && data_size)
                 ADFH_Write_All_Data(id_out, NULL, (const char *)data, &ierr);
         }
@@ -1908,7 +1943,7 @@ int cgio_set_dimensions (int cgio_num, double id,
     }
 #if CG_BUILD_HDF5
     else if (cgio->type == CGIO_FILE_HDF5) {
-      ADFH_Put_Dimension_Information(id, data_type, num_dims, dims, HDF5storage_type, &ierr);
+      ADFH_Put_Dimension_Information(id, data_type, num_dims, dims, cgio->storage_type, &ierr);
         if (ierr > 0) return set_error(ierr);
     }
 #endif

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -91,12 +91,6 @@ typedef struct {
     int type;
     int mode;
     double rootid;
-    int access_mode;  /* Per-file parallel/native access mode */
-#if CG_BUILD_PARALLEL
-    MPI_Comm mpi_comm;
-    MPI_Info mpi_info;
-    hid_t pio_mode;
-#endif
 } cgns_io;
 
 static int num_open = 0;
@@ -852,19 +846,6 @@ int cgio_open_file (const char *filename, int file_mode,
     iolist[n].type = file_type;
     iolist[n].mode = file_mode;
     iolist[n].rootid = rootid;
-
-    /* Copy global configuration to per-file settings */
-    iolist[n].access_mode = CGIO_NATIVE_MODE;
-#if CG_BUILD_HDF5
-    if (file_type == CGIO_FILE_HDF5) {
-        iolist[n].access_mode = ctx_cgio.hdf5_access_mode;
-    }
-#endif
-#if CG_BUILD_PARALLEL
-    iolist[n].mpi_comm = ctx_cgio.pcg_mpi_comm;
-    iolist[n].mpi_info = ctx_cgio.pcg_mpi_info;
-    iolist[n].pio_mode = ctx_cgio.default_pio_mode;
-#endif
 
     *cgio_num = n + 1;
     num_open++;

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -857,7 +857,6 @@ int cgio_open_file (const char *filename, int file_mode,
     iolist[n].access_mode = CGIO_NATIVE_MODE;
 #if CG_BUILD_HDF5
     if (file_type == CGIO_FILE_HDF5) {
-        /* Use enum instead of string comparison for efficiency */
         iolist[n].access_mode = ctx_cgio.hdf5_access_mode;
     }
 #endif

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -61,7 +61,6 @@ freely, subject to the following restrictions:
 
 #if CG_BUILD_HDF5
 cgns_io_ctx_t ctx_cgio = {
-    .hdf5_access = "NATIVE",
     .hdf5_access_mode = CGIO_NATIVE_MODE,
 #if CG_BUILD_PARALLEL
     .pcg_mpi_comm = MPI_COMM_NULL,
@@ -813,7 +812,9 @@ int cgio_open_file (const char *filename, int file_mode,
 #endif
 #if CG_BUILD_HDF5
     else if (file_type == CGIO_FILE_HDF5) {
-        ADFH_Database_Open(filename, fmode, ctx_cgio.hdf5_access, &rootid, &ierr);
+        /* Convert enum to string for ADFH API (Issue #836) */
+        const char *format = (ctx_cgio.hdf5_access_mode == CGIO_PARALLEL_MODE) ? "PARALLEL" : "NATIVE";
+        ADFH_Database_Open(filename, fmode, format, &rootid, &ierr);
         if (ierr > 0) return set_error(ierr);
     }
 #endif

--- a/src/cgns_io.c
+++ b/src/cgns_io.c
@@ -91,8 +91,7 @@ typedef struct {
     int type;
     int mode;
     double rootid;
-    int access_mode;
-    int storage_type;  /* HDF5 storage type for this file */
+    int access_mode;  /* Per-file parallel/native access mode */
 #if CG_BUILD_PARALLEL
     MPI_Comm mpi_comm;
     MPI_Info mpi_info;
@@ -160,26 +159,6 @@ static cgns_io *get_cgnsio (int cgio_num, int write)
     last_type = iolist[cgio_num].type;
     last_err = CGIO_ERR_NONE;
     return &iolist[cgio_num];
-}
-
-/*---------------------------------------------------------*/
-
-/* Get per-file storage type */
-static int get_file_storage_type(int cgio_num)
-{
-    cgns_io *cgio = get_cgnsio(cgio_num, 0);
-    if (cgio == NULL) return HDF5storage_type; /* fallback to global */
-    return cgio->storage_type;
-}
-
-/*---------------------------------------------------------*/
-
-/* Get per-file access mode */
-static int get_file_access_mode(int cgio_num)
-{
-    cgns_io *cgio = get_cgnsio(cgio_num, 0);
-    if (cgio == NULL) return CGIO_NATIVE_MODE;
-    return cgio->access_mode;
 }
 
 /*---------------------------------------------------------*/
@@ -875,7 +854,6 @@ int cgio_open_file (const char *filename, int file_mode,
     iolist[n].rootid = rootid;
 
     /* Copy global configuration to per-file settings */
-    iolist[n].storage_type = HDF5storage_type;
     iolist[n].access_mode = CGIO_NATIVE_MODE;
 #if CG_BUILD_HDF5
     if (file_type == CGIO_FILE_HDF5) {
@@ -1220,7 +1198,7 @@ int cgio_new_node (int cgio_num, double pid, const char *name,
       ADFH_Set_Label(*id, label, &ierr);
       if (ierr > 0) return set_error(ierr);
       if (data_type != NULL && strcmp(data_type, "MT")) {
-        ADFH_Put_Dimension_Information(*id, data_type, ndims, dims, cgio->storage_type, &ierr);
+        ADFH_Put_Dimension_Information(*id, data_type, ndims, dims, HDF5storage_type, &ierr);
         if (ierr > 0) return set_error(ierr);
         if (data != NULL) {
           ADFH_Write_All_Data(*id, NULL, (const char *)data, &ierr);
@@ -1380,7 +1358,7 @@ int cgio_copy_node (int cgio_num_inp, double id_inp,
         ADFH_Set_Label(id_out, label, &ierr);
         if (ierr <= 0) {
             ADFH_Put_Dimension_Information(id_out, data_type, ndims,
-                                           dims, output->storage_type, &ierr);
+                                           dims, HDF5storage_type, &ierr);
             if (ierr <= 0 && data_size)
                 ADFH_Write_All_Data(id_out, NULL, (const char *)data, &ierr);
         }
@@ -1943,7 +1921,7 @@ int cgio_set_dimensions (int cgio_num, double id,
     }
 #if CG_BUILD_HDF5
     else if (cgio->type == CGIO_FILE_HDF5) {
-      ADFH_Put_Dimension_Information(id, data_type, num_dims, dims, cgio->storage_type, &ierr);
+      ADFH_Put_Dimension_Information(id, data_type, num_dims, dims, HDF5storage_type, &ierr);
         if (ierr > 0) return set_error(ierr);
     }
 #endif

--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -515,7 +515,10 @@ int cgp_open(const char *filename, int mode, int *fn)
       cgp_mpi_comm(MPI_COMM_WORLD);
     }
 
-    /* Flag this as a parallel access */
+    /* Set global parallel access mode for this file open.
+     * Note: HDF5 will remember the MPIO driver with the file handle after opening.
+     * The global state is only used at file open time to configure HDF5.
+     * Do NOT reset this in cgp_close() - it would corrupt subsequent parallel opens. */
     strcpy(ctx_cgio.hdf5_access,"PARALLEL");
     ctx_cgio.hdf5_access_mode = CGIO_PARALLEL_MODE;
 
@@ -536,6 +539,10 @@ int cgp_open(const char *filename, int mode, int *fn)
  * \param[in]  fn \FILE_fn
  * \return \ier
  * \details Similar to cg_close() and calls that routine.
+ * \note IMPORTANT: This function must NOT reset ctx_cgio.hdf5_access to "NATIVE"
+ *       as that would corrupt the access mode for other open parallel files.
+ *       HDF5 maintains the MPIO driver with each file handle, so resetting the
+ *       global state is both unnecessary and harmful. (Issue #836)
  */
 int cgp_close(int fn)
 {

--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -529,7 +529,6 @@ int cgp_open(const char *filename, int mode, int *fn)
      * Note: HDF5 will remember the MPIO driver with the file handle after opening.
      * The global state is only used at file open time to configure HDF5.
      * Do NOT reset this in cgp_close() - it would corrupt subsequent parallel opens. */
-    strcpy(ctx_cgio.hdf5_access,"PARALLEL");
     ctx_cgio.hdf5_access_mode = CGIO_PARALLEL_MODE;
 
     ierr = cg_set_file_type(CG_FILE_HDF5);
@@ -549,7 +548,7 @@ int cgp_open(const char *filename, int mode, int *fn)
  * \param[in]  fn \FILE_fn
  * \return \ier
  * \details Similar to cg_close() and calls that routine.
- * \note IMPORTANT: This function must NOT reset ctx_cgio.hdf5_access to "NATIVE"
+ * \note IMPORTANT: This function must NOT reset ctx_cgio.hdf5_access_mode to NATIVE
  *       as that would corrupt the access mode for other open parallel files.
  *       HDF5 maintains the MPIO driver with each file handle, so resetting the
  *       global state is both unnecessary and harmful. (Issue #836)

--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -501,9 +501,19 @@ void cgp_error_exit(void)
  * \param[in]  mode     \FILE_mode
  * \param[out] fn       \FILE_fn
  * \return \ier
- * \details Similar to cg_open() and calls that routine. The differences
+ * \details Similar to cg_open() and calls that routine. The difference
  *          is that cgp_open() explicitly sets an internal CGNS flag to
  *          indicate parallel access.
+ *
+ * \warning IMPORTANT: The library uses global state for the parallel/native access mode.
+ *          When MPI is initialized, calling cgp_open() sets the mode to PARALLEL globally.
+ *          Any subsequent calls to cg_open() in the same MPI program may also use parallel
+ *          mode until all files are closed. Mixing cgp_open() and cg_open() in the same
+ *          MPI program is not recommended and behavior is undefined.
+ *
+ * \note Multiple parallel files can be open simultaneously. Each file's HDF5 handle
+ *       maintains its own MPIO driver state independently, even though CGNS uses
+ *       global configuration at file open time. (See Issue #836)
  */
 int cgp_open(const char *filename, int mode, int *fn)
 {

--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -517,6 +517,7 @@ int cgp_open(const char *filename, int mode, int *fn)
 
     /* Flag this as a parallel access */
     strcpy(ctx_cgio.hdf5_access,"PARALLEL");
+    ctx_cgio.hdf5_access_mode = CGIO_PARALLEL_MODE;
 
     ierr = cg_set_file_type(CG_FILE_HDF5);
     if (ierr) return ierr;

--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -523,11 +523,6 @@ int cgp_open(const char *filename, int mode, int *fn)
     ierr = cg_open(filename, mode, fn);
     cgns_filetype = old_type;
 
-    /* reset parallel access
-     * the global hdf5_access is only used at file opening
-     */
-    strcpy(ctx_cgio.hdf5_access,"NATIVE");
-
     return ierr;
 }
 

--- a/src/ptests/open_close.c
+++ b/src/ptests/open_close.c
@@ -190,7 +190,7 @@ int main(int argc, char* argv[]) {
                 cgp_error_exit();
 
             /* Close the first file
-             * This would reset hdf5_access to NATIVE before the fix */
+             * This would reset hdf5_access_mode to NATIVE before the fix */
             if (cgp_close(fn1))
                 cgp_error_exit();
 

--- a/src/ptests/open_close.c
+++ b/src/ptests/open_close.c
@@ -133,6 +133,82 @@ int main(int argc, char* argv[]) {
         if (cgp_close(fn))
           cgp_error_exit();
 
+        /* Test for GitHub issue #836: multiple parallel file operations
+         * Verify that closing one file doesn't corrupt parallel access mode
+         * for other open files */
+        {
+            int fn1, fn2, B, Z, C;
+            cgsize_t sizes[9];
+            cgsize_t rmin[3], rmax[3];
+            double coord_array[10];
+            int i;
+
+            if (comm_rank == 0)
+                printf("Testing multiple parallel file operations\n");
+
+            /* Open first file in parallel mode */
+            if (cgp_open("test_multi_file1.cgns", CG_MODE_WRITE, &fn1))
+                cgp_error_exit();
+
+            /* Create base and zone in file 1 */
+            sizes[0] = comm_size * 10;
+            sizes[1] = 1;
+            sizes[2] = 1;
+            sizes[3] = sizes[0] - 1;
+            sizes[4] = 0;
+            sizes[5] = 0;
+            sizes[6] = 0;
+            sizes[7] = 0;
+            sizes[8] = 0;
+
+            if (cg_base_write(fn1, "Base", 3, 3, &B) ||
+                cg_zone_write(fn1, B, "Zone", sizes, CGNS_ENUMV(Structured), &Z) ||
+                cgp_coord_write(fn1, B, Z, CGNS_ENUMV(RealDouble), "CoordinateX", &C))
+                cgp_error_exit();
+
+            /* Open second file in parallel mode */
+            if (cgp_open("test_multi_file2.cgns", CG_MODE_WRITE, &fn2))
+                cgp_error_exit();
+
+            /* Create base and zone in file 2 */
+            if (cg_base_write(fn2, "Base", 3, 3, &B) ||
+                cg_zone_write(fn2, B, "Zone", sizes, CGNS_ENUMV(Structured), &Z) ||
+                cgp_coord_write(fn2, B, Z, CGNS_ENUMV(RealDouble), "CoordinateY", &C))
+                cgp_error_exit();
+
+            /* Write data to file 1 */
+            rmin[0] = comm_rank * 10 + 1;
+            rmin[1] = 1;
+            rmin[2] = 1;
+            rmax[0] = (comm_rank + 1) * 10;
+            rmax[1] = 1;
+            rmax[2] = 1;
+            for (i = 0; i < 10; i++)
+                coord_array[i] = (double)(comm_rank * 10 + i);
+
+            if (cgp_coord_write_data(fn1, B, Z, C, rmin, rmax, coord_array))
+                cgp_error_exit();
+
+            /* Close the first file
+             * This would reset hdf5_access to NATIVE before the fix */
+            if (cgp_close(fn1))
+                cgp_error_exit();
+
+            /* Write to file 2 - should still work in parallel mode
+             * This would fail previously */
+            for (i = 0; i < 10; i++)
+                coord_array[i] = (double)(comm_rank * 10 + i + 100);
+
+            if (cgp_coord_write_data(fn2, B, Z, C, rmin, rmax, coord_array))
+                cgp_error_exit();
+
+            if (cgp_close(fn2))
+                cgp_error_exit();
+
+            if (comm_rank == 0)
+                printf("  Multiple parallel file test passed\n");
+        }
+
 	err = MPI_Finalize();
 	if(err!=MPI_SUCCESS) cgp_doError;
 	return err;


### PR DESCRIPTION
Fixes #836: removes the global hdf5_access reset, which corrupts parallel file operations, and adds a test.