### PR TITLE
Fix memory leaks

### DIFF
--- a/src/adf/ADF_internals.c
+++ b/src/adf/ADF_internals.c
@@ -702,8 +702,10 @@ if( parent_node.entries_for_sub_nodes <= parent_node.num_sub_nodes ) {
    if( old_num_entries > 0 ) {
       ADFI_read_sub_node_table( file_index, &parent_node.sub_node_table,
 	   sub_node_table, error_return ) ;
-      if( *error_return != NO_ERROR )
+      if( *error_return != NO_ERROR ) {
+         free( sub_node_table ) ;
          return ;
+      }
       } /* end if */
 
 	/** Blank out the new part of the sub-node_table **/
@@ -720,15 +722,19 @@ if( parent_node.entries_for_sub_nodes <= parent_node.num_sub_nodes ) {
    if( parent_node.num_sub_nodes > 0 ) { /* delete old table from file */
       ADFI_delete_sub_node_table( file_index, &parent_node.sub_node_table,
                                   old_num_entries, error_return ) ;
-      if( *error_return != NO_ERROR )
+      if( *error_return != NO_ERROR ) {
+         free( sub_node_table ) ;
          return ;
+      }
       } /* end if */
 
   ADFI_file_malloc( file_index, TAG_SIZE + DISK_POINTER_SIZE + TAG_SIZE +
     parent_node.entries_for_sub_nodes * (ADF_NAME_LENGTH + DISK_POINTER_SIZE),
     &tmp_disk_ptr, error_return ) ;
-   if( *error_return != NO_ERROR )
+   if( *error_return != NO_ERROR ) {
+      free( sub_node_table ) ;
       return ;
+   }
 
    parent_node.sub_node_table.block = tmp_disk_ptr.block ;
    parent_node.sub_node_table.offset = tmp_disk_ptr.offset ;
@@ -1654,8 +1660,10 @@ if( parent_node.entries_for_sub_nodes > 0 ) {
 for( i=0; i<(int)parent_node.num_sub_nodes; i++ ) {
    ADFI_compare_node_names( sub_node_table[i].child_name, name,
 	found, error_return ) ;
-   if( *error_return != NO_ERROR )
-      break ;
+   if( *error_return != NO_ERROR ) {
+      free( sub_node_table ) ;
+      return ;
+   }
    if( *found == 1 ) {	/* name was found, save off addresses */
       sub_node_entry_location->block = parent_node.sub_node_table.block ;
       sub_node_entry_location->offset = parent_node.sub_node_table.offset +
@@ -1663,8 +1671,10 @@ for( i=0; i<(int)parent_node.num_sub_nodes; i++ ) {
 		(ADF_NAME_LENGTH + DISK_POINTER_SIZE) * i ;
 
       ADFI_adjust_disk_pointer( sub_node_entry_location, error_return ) ;
-      if( *error_return != NO_ERROR )
+      if( *error_return != NO_ERROR ) {
+         free( sub_node_table ) ;
          return ;
+      }
 
 	/** Also save off the child's name **/
       strncpy( sub_node_entry->child_name, sub_node_table[i].child_name,
@@ -2756,15 +2766,19 @@ default : /** Multiple data-chunks to free.  Free them,
     /** Read in the table **/
    ADFI_read_data_chunk_table( file_index, &node_header->data_chunks,
                                data_chunk_table, error_return ) ;
-   if( *error_return != NO_ERROR )
+   if( *error_return != NO_ERROR ) {
+      free( data_chunk_table ) ;
       return ;
+      }
 
     /** Free each entry in the table **/
    for( i=0; i<(int)node_header->number_of_data_chunks; i++ ) {
       ADFI_file_free( file_index, &data_chunk_table[i].start,
                       0, error_return ) ;
-      if( *error_return != NO_ERROR )
+      if( *error_return != NO_ERROR ) {
+         free( data_chunk_table ) ;
          return ;
+         }
       } /* end for */
    free( data_chunk_table ) ;
    ADFI_file_free( file_index, &node_header->data_chunks, 0, error_return ) ;
@@ -2870,14 +2884,18 @@ strncpy ( sub_node_table[i].child_name,
 ADFI_write_sub_node_table( file_index, &parent_node.sub_node_table,
                            parent_node.entries_for_sub_nodes,
                            sub_node_table, error_return ) ;
-if( *error_return != NO_ERROR )
+if( *error_return != NO_ERROR ) {
+   free( sub_node_table ) ;
    return ;
+}
 
     /** Update the sub-node count and write the parent's node-header **/
 parent_node.num_sub_nodes -= 1;
 ADFI_write_node_header( file_index, parent, &parent_node, error_return ) ;
-if( *error_return != NO_ERROR )
+if( *error_return != NO_ERROR ) {
+   free( sub_node_table ) ;
    return ;
+}
 
 /** Clear all subnode/disk entries off the priority stack for file **/
 ADFI_stack_control(file_index, 0, 0, CLEAR_STK_TYPE, SUBNODE_STK,

--- a/src/adfh/ADFH.c
+++ b/src/adfh/ADFH.c
@@ -1446,16 +1446,36 @@ static herr_t fix_dimensions(hid_t id, const char *name, const H5L_info_t* linfo
   int err;
   char type[ADF_DATA_TYPE_LENGTH+1];
 
-  if (*name != D_PREFIX && (gid = H5Gopen2(id, name, H5P_DEFAULT)) >= 0 &&
-     !get_str_att(gid, A_TYPE, type, &err) && strcmp(type, ADFH_LK)) {
-#if ADFH_HDF5_HAVE_112_API
-    H5Literate2(gid, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, fix_dimensions, NULL);
-#else
-    H5Literate(gid, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, fix_dimensions, NULL);
-#endif
-    transpose_dimensions(gid,name);
+  /* Skip names starting with D_PREFIX */
+  if (*name == D_PREFIX)
+    return 0;
+
+  /* Try to open the group */
+  gid = H5Gopen2(id, name, H5P_DEFAULT);
+  if (gid < 0)
+    return 0;
+
+  /* Get the type attribute */
+  if (get_str_att(gid, A_TYPE, type, &err) != 0) {
     H5Gclose(gid);
+    return 0;
   }
+
+  /* Skip if type is ADFH_LK */
+  if (strcmp(type, ADFH_LK) == 0) {
+    H5Gclose(gid);
+    return 0;
+  }
+
+  /* Process the group */
+#if ADFH_HDF5_HAVE_112_API
+  H5Literate2(gid, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, fix_dimensions, NULL);
+#else
+  H5Literate(gid, H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, NULL, fix_dimensions, NULL);
+#endif
+  transpose_dimensions(gid,name);
+  H5Gclose(gid);
+
   return 0;
 }
 

--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -14158,7 +14158,6 @@ cgns_descr *cgi_descr_address(int local_mode, int given_no,
             return CG_OK;
         }
         cgi_free_descr(descr);
-        return CG_OK;
     }
     return descr;
 }
@@ -14517,7 +14516,6 @@ cgns_units *cgi_units_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_units(units);
-        return CG_OK;
     }
     return units;
 }
@@ -14736,7 +14734,6 @@ cgns_conversion *cgi_conversion_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_convert(convert);
-        return CG_OK;
     }
     return convert;
 }
@@ -14780,7 +14777,6 @@ cgns_exponent *cgi_exponent_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_exponents(exponents);
-        return CG_OK;
     }
     return exponents;
 }
@@ -14831,7 +14827,6 @@ cgns_integral *cgi_integral_address(int local_mode, int given_no,
             return CG_OK;
         }
         cgi_free_integral(integral);
-        return CG_OK;
     }
     return integral;
 }
@@ -14878,7 +14873,6 @@ cgns_equations *cgi_equations_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_equations(equations);
-        return CG_OK;
     }
     return equations;
 }
@@ -14938,7 +14932,6 @@ cgns_state *cgi_state_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_state(state);
-        return CG_OK;
     }
     return state;
 }
@@ -14990,7 +14983,6 @@ cgns_converg *cgi_converg_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_converg(converg);
-        return CG_OK;
     }
     return converg;
 }
@@ -15034,7 +15026,6 @@ cgns_governing *cgi_governing_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_governing(governing);
-        return CG_OK;
     }
     return governing;
 }
@@ -15085,7 +15076,6 @@ int *cgi_diffusion_address(int local_mode, int *ier)
             CGNS_FREE(id);
         }
         CGNS_FREE(diffusion_model);
-        return CG_OK;
     }
     return diffusion_model;
 }

--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -10594,10 +10594,6 @@ int cgi_array_general_write(
 
     if (have_dup) {
          /* overwrite a DataArray_t node of same name, size and data-type: */
-        if (array == NULL) {
-            cgi_error("Internal error: array pointer is NULL");
-            return CG_ERROR;
-        }
          /* array rank in file must agree */
         if (array->data_dim != s_numdim) {
             cgi_error("Mismatch in array rank");

--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -234,6 +234,7 @@ int cgi_read_all_base_children(double base_id, int* nnodes, _childnode_t** child
     if (cgio_children_ids(cg->cgio, base_id, 1, nchildren,
         &len, idlist)) {
         cg_io_error("cgio_children_ids");
+        CGNS_FREE(idlist);
         return CG_ERROR;
     }
     if (len != nchildren) {
@@ -247,6 +248,8 @@ int cgi_read_all_base_children(double base_id, int* nnodes, _childnode_t** child
         /* Get the node label */
         if (cgio_get_label(cg->cgio, idlist[n], nodelabel)) {
             cg_io_error("cgio_get_label");
+            CGNS_FREE(idlist);
+            CGNS_FREE(childlist);
             return CG_ERROR;
         }
         childlist[n].type = get_base_label_type_as_enum(nodelabel);
@@ -259,6 +262,8 @@ int cgi_read_all_base_children(double base_id, int* nnodes, _childnode_t** child
             /* Get also the node name */
             if (cgio_get_name(cg->cgio, idlist[n], childlist[nid].name)) {
                 cg_io_error("cgio_get_name");
+                CGNS_FREE(idlist);
+                CGNS_FREE(childlist);
                 return CG_ERROR;
             }
             nid++;
@@ -6538,6 +6543,11 @@ int cgi_read_subregion(int in_link, double parent_id, int *nsubreg,
                 if (cgi_read_string(idi[i], name, &text)) return CG_ERROR;
                 if (strcmp(name, "BCRegionName") &&
                     strcmp(name, "GridConnectivityRegionName")) {
+                    if (j >= ndescr) {
+                        cgi_error("Descriptor count mismatch in ZoneSubRegion");
+                        CGNS_FREE(text);
+                        return CG_ERROR;
+                    }
                     reg[n].descr[j].id = idi[i];
                     reg[n].descr[j].link = cgi_read_link(idi[i]);
                     reg[n].descr[j].in_link = in_link;
@@ -10560,7 +10570,7 @@ int cgi_array_general_write(
     const int access_full_range =
         (s_access_full_range == 1) && (m_access_full_range == 1);
 
-    cgns_array *array;
+    cgns_array *array = NULL;
 
      /* check for existing array */
     int have_dup = 0;
@@ -10584,6 +10594,10 @@ int cgi_array_general_write(
 
     if (have_dup) {
          /* overwrite a DataArray_t node of same name, size and data-type: */
+        if (array == NULL) {
+            cgi_error("Internal error: array pointer is NULL");
+            return CG_ERROR;
+        }
          /* array rank in file must agree */
         if (array->data_dim != s_numdim) {
             cgi_error("Mismatch in array rank");
@@ -14144,6 +14158,7 @@ cgns_descr *cgi_descr_address(int local_mode, int given_no,
             return CG_OK;
         }
         cgi_free_descr(descr);
+        return CG_OK;
     }
     return descr;
 }
@@ -14502,6 +14517,7 @@ cgns_units *cgi_units_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_units(units);
+        return CG_OK;
     }
     return units;
 }
@@ -14720,6 +14736,7 @@ cgns_conversion *cgi_conversion_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_convert(convert);
+        return CG_OK;
     }
     return convert;
 }
@@ -14763,6 +14780,7 @@ cgns_exponent *cgi_exponent_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_exponents(exponents);
+        return CG_OK;
     }
     return exponents;
 }
@@ -14813,6 +14831,7 @@ cgns_integral *cgi_integral_address(int local_mode, int given_no,
             return CG_OK;
         }
         cgi_free_integral(integral);
+        return CG_OK;
     }
     return integral;
 }
@@ -14859,6 +14878,7 @@ cgns_equations *cgi_equations_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_equations(equations);
+        return CG_OK;
     }
     return equations;
 }
@@ -14918,6 +14938,7 @@ cgns_state *cgi_state_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_state(state);
+        return CG_OK;
     }
     return state;
 }
@@ -14969,6 +14990,7 @@ cgns_converg *cgi_converg_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_converg(converg);
+        return CG_OK;
     }
     return converg;
 }
@@ -15012,6 +15034,7 @@ cgns_governing *cgi_governing_address(int local_mode, int *ier)
             return CG_OK;
         }
         cgi_free_governing(governing);
+        return CG_OK;
     }
     return governing;
 }
@@ -15062,6 +15085,7 @@ int *cgi_diffusion_address(int local_mode, int *ier)
             CGNS_FREE(id);
         }
         CGNS_FREE(diffusion_model);
+        return CG_OK;
     }
     return diffusion_model;
 }


### PR DESCRIPTION
Fix memory leaks in ADF_internals.c sub_node_table error paths

Add missing free() calls for sub_node_table allocations on error returns in:
- ADFI_add_2_sub_node_table
- ADFI_check_4_child_name
- ADFI_delete_from_sub_node_table

Also fixed data_chunk_table leaks in ADFI_delete_data

Resolves SonarQube memory leak warnings.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix memory leaks in error paths by adding missing `free()` calls in `ADF_internals.c`, `ADFH.c`, and `cgns_internals.c`.
> 
>   - **Memory Management**:
>     - Add missing `free()` calls for `sub_node_table` in `ADFI_add_2_sub_node_table`, `ADFI_check_4_child_name`, and `ADFI_delete_from_sub_node_table` in `ADF_internals.c`.
>     - Fix `data_chunk_table` leaks in `ADFI_delete_data` in `ADF_internals.c`.
>     - Add `CGNS_FREE` calls for `idlist` and `childlist` in `cgi_read_all_base_children` in `cgns_internals.c`.
>   - **Error Handling**:
>     - Add error handling for `H5Gopen2` and `get_str_att` in `fix_dimensions` in `ADFH.c`.
>     - Add error handling for descriptor count mismatch in `cgi_read_subregion` in `cgns_internals.c`.
>   - **Misc**:
>     - Initialize `cgns_array` to `NULL` in `cgi_array_general_write` in `cgns_internals.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for 36b89d82edb8192e7e994cd900e51aa6bb8a270a. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->