### PR TITLE
Doxygen updates

### DIFF
--- a/src/cgnslib.h
+++ b/src/cgnslib.h
@@ -40,7 +40,7 @@
  *          
  * ------------------------------------------------------------------------- */
 /**
- * \defgroup CGNSInternals_FNC_CG_CONFIG Configuring CGNS Internals; valid cg_configure() options.
+ * \defgroup CGNSInternals_FNC_CG_CONFIG Configuring CGNS Internals
  */
 #ifndef CGNSLIB_H
 #define CGNSLIB_H

--- a/src/doxygen/CGNSNav.dox
+++ b/src/doxygen/CGNSNav.dox
@@ -1,7 +1,7 @@
 /**
  *
  * \page CGNS_Navigation_Ill
- * \section CGNS_Navigation_Ill CGNS File Navigation Illustration
+ * \section CGNS_Navigation_Illustration CGNS File Navigation Illustration
  * 
  * To illustrate the use of the accessing a node routines, assume you have a file with CGNS
  * index number \e filenum, a base node named \e Base with index number \e basenum, 2 zones


### PR DESCRIPTION
Fixed group title mismatch
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix documentation inconsistencies in `cgnslib.h` and `CGNSNav.dox` by correcting group and section titles.
> 
>   - **Documentation**:
>     - Fix group title in `cgnslib.h` by removing the semicolon and extra text from `\defgroup CGNSInternals_FNC_CG_CONFIG`.
>     - Correct section name in `CGNSNav.dox` from `CGNS_Navigation_Ill` to `CGNS_Navigation_Illustration` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for ef04e984fadab630f2a86bc8458a739f721ceffd. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->