### PR TITLE
Cray compiler Fortran intent(in) issue

### DIFF
--- a/src/cgns_f.F90
+++ b/src/cgns_f.F90
@@ -6365,7 +6365,7 @@ CONTAINS
         IMPORT :: c_int, c_char
         IMPLICIT NONE
         INTEGER(c_int), VALUE :: fn
-        CHARACTER(KIND=C_CHAR), DIMENSION(*) :: name1
+        CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: name1
         INTEGER(c_int), VALUE :: index1
       END FUNCTION cg_gorel_fc1
     END INTERFACE


### PR DESCRIPTION
Compiling using develop, 4.5.0, or 4.5.1 on a Cray system runs into an issue with Fortran's intent for variables:
```
INTEGER(c_int) FUNCTION cg_gorel_fc1(fn, name1, index1) BIND(C, name="cg_gorel_fc1")
                                               ^                                           
ftn-828 ftn: ERROR CG_GOREL_FC1, File = cgns_f.F90, Line = 6233, Column = 48 
  Procedure "cg_gorel_fc1" is defined in multiple places.  Argument 2 has INTENT(IN) in one definition but not the other.
```
(I also opened an issue but will close it since the fix is here)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Cray compiler error by adding `INTENT(IN)` to `name1` in `cg_gorel_fc1` in `cgns_f.F90`.
> 
>   - **Fix**:
>     - Add `INTENT(IN)` to `name1` argument in `cg_gorel_fc1` function in `cgns_f.F90` to resolve Cray compiler error regarding inconsistent intent definitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for bba05aa93e79ec411620808a332f4da6e4502900. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->