### PR TITLE
Fixes  incorrectly sizing the ParentElements for parallel

### DIFF
--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -1439,11 +1439,8 @@ int cgp_parent_data_write(int fn, int B, int Z, int S,
         section->parelem = CGNS_NEW(cgns_array, 1);
     }
 
-    /* Get total size across all processors */
-    cgsize_t num = end == 0 ? 0 : end - start + 1;
-    num = num < 0 ? 0 : num;
-    MPI_Datatype mpi_type = sizeof(cgsize_t) == 32 ? MPI_INT : MPI_LONG_LONG_INT;
-    MPI_Allreduce(MPI_IN_PLACE, &num, 1, mpi_type, MPI_SUM, ctx_cgio.pcg_mpi_comm);
+    /* ParentElements array must be sized to full section range */
+    cgsize_t num = section->range[1] - section->range[0] + 1;
 
     strcpy(section->parelem->data_type, CG_SIZE_DATATYPE);
     section->parelem->data_dim = 2;
@@ -1476,7 +1473,7 @@ int cgp_parent_data_write(int fn, int B, int Z, int S,
 
     if (cgi_write_array(section->id, section->parface)) return CG_ERROR;
 
-    /* ParentElements -- write data */
+    /* Calculate write range based on element numbers relative to section start */
     rmin[0] = start - section->range[0] + 1;
     rmax[0] = end - section->range[0] + 1;
     rmin[1] = 1;
@@ -1486,6 +1483,7 @@ int cgp_parent_data_write(int fn, int B, int Z, int S,
     cg_rw_t Data;
     Data.u.wbuf = parent_data;
 
+    /* Write ParentElements data */
     to_HDF_ID(section->parelem->id, hid);
     int herr = readwrite_data_parallel(hid, type, 2, rmin, rmax, &Data, CG_PAR_WRITE);
     if (herr != CG_OK)
@@ -1625,11 +1623,8 @@ int cgp_parentelements_write_data(int fn, int B, int Z, int S, cgsize_t start,
         section->parelem = CGNS_NEW(cgns_array, 1);
     }
 
-    /* Get total size across all processors */
-    cgsize_t num = end == 0 ? 0 : end - start + 1;
-    num = num < 0 ? 0 : num;
-    MPI_Datatype mpi_type = sizeof(cgsize_t) == 32 ? MPI_INT : MPI_LONG_LONG_INT;
-    MPI_Allreduce(MPI_IN_PLACE, &num, 1, mpi_type, MPI_SUM, ctx_cgio.pcg_mpi_comm);
+    /* ParentElements array must be sized to full section range */
+    cgsize_t num = section->range[1] - section->range[0] + 1;
 
     strcpy(section->parelem->data_type, CG_SIZE_DATATYPE);
     section->parelem->data_dim = 2;

--- a/src/ptests/test_unstruc_quad.c
+++ b/src/ptests/test_unstruc_quad.c
@@ -405,6 +405,8 @@ int main(int argc, char* argv[]) {
       if (read_data[i] != parent_data[i]) {
         printf("Rank %d: ParentElements mismatch at index %ld: expected %ld, got %ld\n",
                comm_rank, (long)i, (long)parent_data[i], (long)read_data[i]);
+        free(parent_data);
+        free(read_data);
         MPI_Abort(MPI_COMM_WORLD, 1);
       }
     }

--- a/src/ptests/test_unstruc_quad.c
+++ b/src/ptests/test_unstruc_quad.c
@@ -342,6 +342,77 @@ int main(int argc, char* argv[]) {
     free(point_list);
   }
 
+  /* Regression test for ParentElements with non-contiguous element ranges.
+   * Tests fix for bug where ParentElements array was incorrectly sized
+   * causing data scrambling when multiple ranks wrote to different element ranges.
+   * Requires at least 4 ranks to test.
+   */
+  if (comm_size >= 4) {
+    int S_test;
+    cgsize_t test_start, test_end, test_nelem;
+    cgsize_t *parent_data = NULL;
+
+    /* Create test section with elements 101-124 (24 total, 6 per rank in 4-rank case) */
+    cgsize_t section_start = 101;
+    cgsize_t section_end = 100 + 6 * comm_size;
+
+    if (cgp_section_write(fn, B, Z, "TestSection", CGNS_ENUMV(BAR_2),
+                          section_start, section_end, 0, &S_test))
+      cgp_error_exit();
+
+    /* Each rank writes to non-contiguous ranges:
+     * Rank 0: elements 110-114 (5 elements)
+     * Rank 1: element  115     (1 element)
+     * Rank 2: elements 116-118 (3 elements)
+     * Rank 3: elements 119-121 (3 elements)
+     * ... pattern continues for more ranks
+     */
+    if (comm_rank == 0) {
+      test_start = 110;
+      test_end = 114;
+    } else if (comm_rank == 1) {
+      test_start = 115;
+      test_end = 115;
+    } else if (comm_rank == 2) {
+      test_start = 116;
+      test_end = 118;
+    } else {
+      /* For rank 3 and higher */
+      test_start = 119 + (comm_rank - 3) * 3;
+      test_end = test_start + 2;
+    }
+
+    test_nelem = test_end - test_start + 1;
+    parent_data = (cgsize_t *)malloc(test_nelem * 2 * sizeof(cgsize_t));
+
+    /* Fill with rank-specific data */
+    for (cgsize_t i = 0; i < test_nelem; i++) {
+      parent_data[2*i]   = (comm_rank + 1) * 10 + i;  /* Parent element */
+      parent_data[2*i+1] = 0;                         /* Parent face */
+    }
+
+    /* Write ParentElements */
+    if (cgp_parentelements_write_data(fn, B, Z, S_test, test_start, test_end, parent_data))
+      cgp_error_exit();
+
+    /* Read back and verify */
+    cgsize_t *read_data = (cgsize_t *)malloc(test_nelem * 2 * sizeof(cgsize_t));
+    if (cgp_parentelements_read_data(fn, B, Z, S_test, test_start, test_end, read_data))
+      cgp_error_exit();
+
+    /* Verify data */
+    for (cgsize_t i = 0; i < test_nelem * 2; i++) {
+      if (read_data[i] != parent_data[i]) {
+        printf("Rank %d: ParentElements mismatch at index %ld: expected %ld, got %ld\n",
+               comm_rank, (long)i, (long)parent_data[i], (long)read_data[i]);
+        MPI_Abort(MPI_COMM_WORLD, 1);
+      }
+    }
+
+    free(parent_data);
+    free(read_data);
+  }  /* end comm_size >= 4 */
+
   if (cgp_close(fn)) cgp_error_exit();
 
   err = MPI_Finalize();


### PR DESCRIPTION

Fixes bug were cgp_parentelements_write_data() and cgp_parent_data_write() were incorrectly sizing the ParentElements array to the sum of elements across all ranks instead of the full section element range. Added regression test.

Fixes #924 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `ParentElements` array sizing bug in `cgp_parentelements_write_data()` and `cgp_parent_data_write()` and adds regression test for non-contiguous element ranges.
> 
>   - **Behavior**:
>     - Fixes bug in `cgp_parentelements_write_data()` and `cgp_parent_data_write()` in `pcgnslib.c` by sizing `ParentElements` array to full section range.
>     - Adds regression test in `test_unstruc_quad.c` for non-contiguous element ranges with at least 4 ranks.
>   - **Misc**:
>     - Removes MPI_Allreduce call for `num` calculation in `pcgnslib.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for e35b7c7a334fbc1dfabf87785de5b43d69e0dee3. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->