### PR TITLE
Fixes for cg_conn_write to be parallel enabled

### DIFF
--- a/src/cgns_internals.c
+++ b/src/cgns_internals.c
@@ -12546,6 +12546,27 @@ static int cgi_next_posit(char *label, int index, char *name)
                            label, 1, c->cprop->id);
             }
         }
+        else if (0 == strcmp (label, "IndexArray_t")) {
+            int current_count = 0;
+
+            /* Check PointList (Receiver) */
+            if (c->ptset.name[0] != '\0') {
+                current_count++;
+                if (index == current_count || 0 == strcmp(c->ptset.name, name)) {
+                    return cgi_add_posit(&c->ptset, label, 1, c->ptset.id);
+                }
+            }
+
+            /* Check PointListDonor (Donor) */
+            if (c->dptset.name[0] != '\0') {
+                current_count++;
+                if (index == current_count || 0 == strcmp(c->dptset.name, name)) {
+                    return cgi_add_posit(&c->dptset, label, 1, c->dptset.id);
+                }
+            }
+
+            return CG_INCORRECT_PATH;
+        }
         else if (0 == strcmp (label, "UserDefinedData_t")) {
             if (--index < 0) {
                 for (n = 0; n < c->nuser_data; n++) {

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -10178,6 +10178,12 @@ int cg_conn_id(int fn, int B, int Z, int J, double *conn_id)
  *                              ptset_type of PointRange, npnts is always two. For a ptset_type of
  *                              PointList, npnts is the number of points in the PointList.
  * \param[in]  pnts             Array of points defining the interface in the current zone.
+ *                              Post 4.5.1 release, may be NULL when npnts > 0 to create the node
+ *                              structure without data (useful for parallel I/O with PointList).
+ *                              The created node name will be "PointList" (if ptset_type is PointList)
+ *                              or "PointRange" (if ptset_type is PointRange).
+ *                              When NULL, use cg_goto() to navigate to this node
+ *                              and cgp_array_write_data() to write the data in parallel.
  * \param[in]  donorname        Name of the zone interfacing with the current zone.
  * \param[in]  donor_zonetype   Type of the donor zone. The admissible types are Structured and
  *                              Unstructured.
@@ -10190,11 +10196,28 @@ int cg_conn_id(int fn, int B, int Z, int J, double *conn_id)
  *                              only for backward compatibility. The donor data is always read as cgsize_t.
  * \param[in]  ndata_donor      Number of points or cells in the current zone. These are paired with points,
  *                              cells, or fractions thereof in the donor zone.
- * \param[in]  donor_data       Array of donor points or cells corresponding to ndata_donor. Note that it is
- *                              possible that the same donor point or cell may be used multiple times.
+ * \param[in]  donor_data       Array of donor points or cells corresponding to ndata_donor.
+ *                              Post 4.5.1 release, may be NULL when ndata_donor > 0 to create the node
+ *                              structure without data (useful for parallel I/O).
+ *                              The created node name will be "PointListDonor" (if donor_ptset_type is PointListDonor)
+ *                              or "CellListDonor" (if donor_ptset_type is CellListDonor).
+ *                              When NULL, use cg_goto() to navigate to this node
+ *                              and cgp_array_write_data() to write the data in parallel.
+ *                              Note that it is possible that the same donor point or cell may be
+ *                              used multiple times.
  * \param[out] J                Interface index number, where 1 ≤ J ≤ nconns.
  * \return \ier
  *
+ * \note For parallel I/O workflows (CGNS version > 4.5.1):
+ *       1. Call cg_conn_write() with pnts=NULL and/or donor_data=NULL to create the node structure.
+ *       2. Use cg_goto() to navigate to the created "PointList" or "PointListDonor" node.
+ *       3. Call cgp_array_write_data() to write the actual index data in parallel.
+ *       This pattern follows the same approach as cg_boco_write() and other parallel I/O operations.
+ *
+ * \warning If pnts or donor_data is NULL and npnts > 0, the corresponding node will be created with
+ *          dimensions set but no data. The data MUST be written later using
+ *          cgp_array_write_data(), otherwise the file will be incomplete and reading
+ *          operations will fail or return undefined values.
  */
 int cg_conn_write(int fn, int B, int Z,  const char * connectname,
           CGNS_ENUMT(GridLocation_t) location,
@@ -10224,8 +10247,8 @@ int cg_conn_write(int fn, int B, int Z,  const char * connectname,
         cgi_error("Invalid input:  GridConnectivityType=%d ?",connect_type);
         return CG_ERROR;
     }
-    // Vertex and CellCenter valid for all dimensions
     bool is_location_valid = false;
+    // Vertex and CellCenter valid for all dimensions
     if (location == CGNS_ENUMV(Vertex) || location == CGNS_ENUMV(CellCenter)) is_location_valid = true;
     switch (cg->base[B-1].cell_dim) {
         case 2:
@@ -10262,10 +10285,6 @@ int cg_conn_write(int fn, int B, int Z,  const char * connectname,
         return CG_ERROR;
     }
     if (ndata_donor) {
-        if (NULL == donor_data) {
-            cgi_error("Invalid input: number of donor points given but data is NULL");
-            return CG_ERROR;
-        }
         if (donor_ptset_type!=CGNS_ENUMV(CellListDonor) &&
             donor_ptset_type!=CGNS_ENUMV(PointListDonor)) {
             cgi_error("Invalid point set type for donor %s",donorname);

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -10437,6 +10437,7 @@ int cg_conn_write(int fn, int B, int Z,  const char * connectname,
     conn->location = location;
     conn->ptset.id = 0;
     conn->ptset.link = 0;
+    strcpy(conn->ptset.name,PointSetTypeName[ptset_type]);
     conn->ptset.type = ptset_type;
     strcpy(conn->ptset.data_type,CG_SIZE_DATATYPE);
     conn->ptset.npts = npnts;

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -10224,12 +10224,23 @@ int cg_conn_write(int fn, int B, int Z,  const char * connectname,
         cgi_error("Invalid input:  GridConnectivityType=%d ?",connect_type);
         return CG_ERROR;
     }
-    if (location != CGNS_ENUMV(Vertex) &&
-        location != CGNS_ENUMV(CellCenter) &&
-        location != CGNS_ENUMV(FaceCenter)  &&
-        location != CGNS_ENUMV(IFaceCenter) &&
-        location != CGNS_ENUMV(JFaceCenter) &&
-        location != CGNS_ENUMV(KFaceCenter)) {
+    // Vertex and CellCenter valid for all dimensions
+    bool is_location_valid = false;
+    if (location == CGNS_ENUMV(Vertex) || location == CGNS_ENUMV(CellCenter)) is_location_valid = true;
+    switch (cg->base[B-1].cell_dim) {
+        case 2:
+            if (location == CGNS_ENUMV(EdgeCenter)) is_location_valid = true;
+            break;
+        case 3:
+            if (location == CGNS_ENUMV(FaceCenter)  ||
+                location == CGNS_ENUMV(IFaceCenter) ||
+                location == CGNS_ENUMV(JFaceCenter) ||
+                location == CGNS_ENUMV(KFaceCenter)) {
+                is_location_valid = true;
+            }
+            break;
+    }
+    if (!is_location_valid) {
         cgi_error("Invalid input:  GridLocation=%d ?",location);
         return CG_ERROR;
     }

--- a/src/cgnslib.h
+++ b/src/cgnslib.h
@@ -1402,21 +1402,21 @@ CGNSDLL int cg_zconn_set(int fn, int B, int Z, int C);
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 CGNSDLL int cg_nholes(int fn, int B, int Z, int *nholes);
-CGNSDLL int cg_hole_info(int fn, int B, int Z, int Ii, char *holename,
+CGNSDLL int cg_hole_info(int fn, int B, int Z, int J, char *holename,
 	CGNS_ENUMT(GridLocation_t) *location,  CGNS_ENUMT(PointSetType_t) *ptset_type,
 	int *nptsets, cgsize_t *npnts);
-CGNSDLL int cg_hole_read(int fn, int B, int Z, int Ii, cgsize_t *pnts);
-CGNSDLL int cg_hole_id(int fn, int B, int Z, int Ii, double *hole_id);
+CGNSDLL int cg_hole_read(int fn, int B, int Z, int J, cgsize_t *pnts);
+CGNSDLL int cg_hole_id(int fn, int B, int Z, int J, double *hole_id);
 CGNSDLL int cg_hole_write(int fn, int B, int Z, const char * holename,
 	CGNS_ENUMT(GridLocation_t) location, CGNS_ENUMT(PointSetType_t) ptset_type,
-	int nptsets, cgsize_t npnts, const cgsize_t * pnts, int *Ii);
+	int nptsets, cgsize_t npnts, const cgsize_t * pnts, int *J);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
  *      Read and write GridConnectivity_t Nodes                          *
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 CGNSDLL int cg_nconns(int fn, int B, int Z, int *nconns);
-CGNSDLL int cg_conn_info(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_conn_info(int file_number, int B, int Z, int J,
 	char *connectname, CGNS_ENUMT(GridLocation_t) *location,
 	CGNS_ENUMT(GridConnectivityType_t) *type,
 	CGNS_ENUMT(PointSetType_t) *ptset_type,
@@ -1425,10 +1425,10 @@ CGNSDLL int cg_conn_info(int file_number, int B, int Z, int Ii,
 	CGNS_ENUMT(PointSetType_t) *donor_ptset_type,
         CGNS_ENUMT(DataType_t) *donor_datatype,
         cgsize_t *ndata_donor);
-CGNSDLL int cg_conn_read(int file_number, int B, int Z, int Ii, cgsize_t *pnts,
+CGNSDLL int cg_conn_read(int file_number, int B, int Z, int J, cgsize_t *pnts,
         CGNS_ENUMT(DataType_t) donor_datatype,
         cgsize_t *donor_data);
-CGNSDLL int cg_conn_id(int fn, int B, int Z, int Ii, double *conn_id);
+CGNSDLL int cg_conn_id(int fn, int B, int Z, int J, double *conn_id);
 CGNSDLL int cg_conn_write(int file_number, int B, int Z,
 	const char * connectname, CGNS_ENUMT(GridLocation_t) location,
 	CGNS_ENUMT(GridConnectivityType_t) type,
@@ -1437,13 +1437,13 @@ CGNSDLL int cg_conn_write(int file_number, int B, int Z,
 	CGNS_ENUMT(ZoneType_t) donor_zonetype,
 	CGNS_ENUMT(PointSetType_t) donor_ptset_type,
         CGNS_ENUMT(DataType_t) donor_datatype,
-        cgsize_t ndata_donor, const cgsize_t *donor_data, int *Ii);
+        cgsize_t ndata_donor, const cgsize_t *donor_data, int *J);
 CGNSDLL int cg_conn_write_short(int file_number, int B, int Z,
 	const char * connectname, CGNS_ENUMT(GridLocation_t) location,
 	CGNS_ENUMT(GridConnectivityType_t) type,
 	CGNS_ENUMT(PointSetType_t) ptset_type,
-	cgsize_t npnts, const cgsize_t * pnts, const char * donorname, int *Ii);
-CGNSDLL int cg_conn_read_short(int file_number, int B, int Z, int Ii,
+	cgsize_t npnts, const cgsize_t * pnts, const char * donorname, int *J);
+CGNSDLL int cg_conn_read_short(int file_number, int B, int Z, int J,
 	cgsize_t *pnts);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -1451,12 +1451,12 @@ CGNSDLL int cg_conn_read_short(int file_number, int B, int Z, int Ii,
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 CGNSDLL int cg_n1to1(int fn, int B, int Z, int *n1to1);
-CGNSDLL int cg_1to1_read(int fn, int B, int Z, int Ii, char *connectname,
+CGNSDLL int cg_1to1_read(int fn, int B, int Z, int J, char *connectname,
 	char *donorname, cgsize_t *range, cgsize_t *donor_range, int *transform);
-CGNSDLL int cg_1to1_id(int fn, int B, int Z, int Ii, double *one21_id);
+CGNSDLL int cg_1to1_id(int fn, int B, int Z, int J, double *one21_id);
 CGNSDLL int cg_1to1_write(int fn, int B, int Z, const char * connectname,
 	const char * donorname, const cgsize_t * range,
-	const cgsize_t * donor_range, const int * transform, int *Ii);
+	const cgsize_t * donor_range, const int * transform, int *J);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
  *      Read all GridConnectivity1to1_t Nodes of a base                  *
@@ -1636,28 +1636,28 @@ CGNSDLL int cg_bc_area_write(int file_number, int B, int Z, int BC,
  *      Read and write GridConnectivityProperty_t/Periodic_t Nodes       *
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-CGNSDLL int cg_conn_periodic_read(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_conn_periodic_read(int file_number, int B, int Z, int J,
 	float *RotationCenter, float *RotationAngle, float *Translation);
-CGNSDLL int cg_conn_periodic_write(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_conn_periodic_write(int file_number, int B, int Z, int J,
 	float const *RotationCenter, float const *RotationAngle,
 	float const *Translation);
-CGNSDLL int cg_1to1_periodic_write(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_1to1_periodic_write(int file_number, int B, int Z, int J,
 	float const *RotationCenter, float const *RotationAngle,
 	float const *Translation);
-CGNSDLL int cg_1to1_periodic_read(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_1to1_periodic_read(int file_number, int B, int Z, int J,
 	float *RotationCenter, float *RotationAngle, float *Translation);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
  *   Read and write GridConnectivityProperty_t/AverageInterface_t Nodes  *
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-CGNSDLL int cg_conn_average_read(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_conn_average_read(int file_number, int B, int Z, int J,
 	CGNS_ENUMT(AverageInterfaceType_t) *AverageInterfaceType);
-CGNSDLL int cg_conn_average_write(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_conn_average_write(int file_number, int B, int Z, int J,
 	CGNS_ENUMT(AverageInterfaceType_t) AverageInterfaceType);
-CGNSDLL int cg_1to1_average_write(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_1to1_average_write(int file_number, int B, int Z, int J,
 	CGNS_ENUMT(AverageInterfaceType_t) AverageInterfaceType);
-CGNSDLL int cg_1to1_average_read(int file_number, int B, int Z, int Ii,
+CGNSDLL int cg_1to1_average_read(int file_number, int B, int Z, int J,
         CGNS_ENUMT(AverageInterfaceType_t) *AverageInterfaceType);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\


### PR DESCRIPTION
This does several fixes in order to allow `cg_conn_write` to be used with `cgp_ptlist_*()` functions.

1. Allows for `donor_data` to be `NULL`
2. Allows for `PointList` and `PointListDonor` to be navigated to (previously could not)

Additionally, this allows for `location` to be `EdgeCenter` when `cell_dim == 2` and adds in checks for the other dimensions as well.

Fixes #929 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `cg_conn_write` for parallel use by allowing `donor_data` to be `NULL`, enabling `PointList` navigation, and supporting `EdgeCenter` location for 2D in `cgnslib.c` and `cgns_internals.c`.
> 
>   - **Behavior**:
>     - `cg_conn_write` now allows `donor_data` to be `NULL` in `cgnslib.c`.
>     - Enables navigation to `PointList` and `PointListDonor` in `cgi_next_posit()` in `cgns_internals.c`.
>     - Supports `EdgeCenter` location for `cell_dim == 2` and checks other dimensions in `cg_conn_write` in `cgnslib.c`.
>   - **Misc**:
>     - Sets `conn->ptset.name` to `PointSetTypeName[ptset_type]` in `cg_conn_write` in `cgnslib.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for c72cbc8853a988fe952a5cc5a04e43dbee09a983. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->