### PR TITLE
Added documentation for user-facing *_id APIs

### DIFF
--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -9710,6 +9710,18 @@ int cg_hole_read(int fn, int B, int Z, int J, cgsize_t *pnts)
     return CG_OK;
 }
 
+/**
+ * \ingroup OversetHoles
+ *
+ * \brief Get the CGIO node identifier of an overset hole
+ *
+ * \param[in]  fn      \FILE_fn
+ * \param[in]  B       \B_Base
+ * \param[in]  Z       \Z_Zone
+ * \param[in]  J       Overset hole index number, where 1 ≤ J ≤ nholes.
+ * \param[out] hole_id CGIO node identifier for the overset hole.
+ * \return \ier
+ */
 int cg_hole_id(int fn, int B, int Z, int J, double *hole_id)
 {
     cgns_hole *hole;
@@ -10782,6 +10794,18 @@ int cg_1to1_read_global(int fn, int B, char **connectname, char **zonename,
     return CG_OK;
 }
 
+/**
+ * \ingroup OneToOneConnectivity
+ *
+ * \brief Get the CGIO node identifier of a 1-to-1 interface
+ *
+ * \param[in]  fn       \FILE_fn
+ * \param[in]  B        \B_Base
+ * \param[in]  Z        \Z_Zone
+ * \param[in]  J        Interface index number, where 1 ≤ J ≤ n1to1.
+ * \param[out] one21_id CGIO node identifier for the 1-to-1 interface.
+ * \return \ier
+ */
 int cg_1to1_id(int fn, int B, int Z, int J, double *one21_id)
 {
     cgns_1to1 *one21;
@@ -11144,6 +11168,18 @@ int cg_boco_read(int fn, int B, int Z, int BC, cgsize_t *pnts, void *NormalList)
     return CG_OK;
 }
 
+/**
+ * \ingroup BoundaryConditionType
+ *
+ * \brief Get the CGIO node identifier of a boundary condition
+ *
+ * \param[in]  fn      \FILE_fn
+ * \param[in]  B       \B_Base
+ * \param[in]  Z       \Z_Zone
+ * \param[in]  BC      \BC
+ * \param[out] boco_id CGIO node identifier for the boundary condition.
+ * \return \ier
+ */
 int cg_boco_id(int fn, int B, int Z, int BC, double *boco_id)
 {
     cgns_boco *boco;

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -9701,6 +9701,7 @@ int cg_hole_read(int fn, int B, int Z, int J, cgsize_t *pnts)
 
 /**
  * \ingroup OversetHoles
+ * \internal
  *
  * \brief Get the CGIO node identifier of an overset hole
  *
@@ -10785,6 +10786,7 @@ int cg_1to1_read_global(int fn, int B, char **connectname, char **zonename,
 
 /**
  * \ingroup OneToOneConnectivity
+ * \internal
  *
  * \brief Get the CGIO node identifier of a 1-to-1 interface
  *
@@ -11159,6 +11161,7 @@ int cg_boco_read(int fn, int B, int Z, int BC, cgsize_t *pnts, void *NormalList)
 
 /**
  * \ingroup BoundaryConditionType
+ * \internal
  *
  * \brief Get the CGIO node identifier of a boundary condition
  *


### PR DESCRIPTION
Added missing documentation for user-facing API *_id. Although these are technically very specialized, they might be useful for advanced users, tool debugging, or general debugging. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added documentation for `cg_hole_id`, `cg_1to1_id`, and `cg_boco_id` functions in `cgnslib.c` to describe parameters and return values.
> 
>   - **Documentation**:
>     - Added documentation for `cg_hole_id` in `cgnslib.c` to describe parameters and return value for retrieving CGIO node identifier of an overset hole.
>     - Added documentation for `cg_1to1_id` in `cgnslib.c` to describe parameters and return value for retrieving CGIO node identifier of a 1-to-1 interface.
>     - Added documentation for `cg_boco_id` in `cgnslib.c` to describe parameters and return value for retrieving CGIO node identifier of a boundary condition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for e3e86a85237406adeaaf2080b290f2dc48d34a06. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->