### PR TITLE
Modernize ZLIB and SZIP dependency detection for HDF5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,17 +162,43 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "zlib-only"
+          # CMake-built HDF5 variants
+          - name: "cmake-zlib-only"
+            hdf5_build: cmake
             zlib: ON
             szip: OFF
             apt_packages: "zlib1g-dev"
-          - name: "libaec-only"
+          - name: "cmake-libaec-only"
+            hdf5_build: cmake
             zlib: OFF
             szip: ON
             apt_packages: "libaec-dev"
-          - name: "both"
+          - name: "cmake-both"
+            hdf5_build: cmake
             zlib: ON
             szip: ON
+            apt_packages: "zlib1g-dev libaec-dev"
+          # Autotools-built HDF5 variants
+          - name: "autotools-zlib-only"
+            hdf5_build: autotools
+            zlib: ON
+            szip: OFF
+            zlib_at: "--with-zlib"
+            szip_at: "--without-szlib"
+            apt_packages: "zlib1g-dev"
+          - name: "autotools-libaec-only"
+            hdf5_build: autotools
+            zlib: OFF
+            szip: ON
+            zlib_at: "--without-zlib"
+            szip_at: "--with-szlib"
+            apt_packages: "libaec-dev"
+          - name: "autotools-both"
+            hdf5_build: autotools
+            zlib: ON
+            szip: ON
+            zlib_at: "--with-zlib"
+            szip_at: "--with-szlib"
             apt_packages: "zlib1g-dev libaec-dev"
 
     name: "HDF5 compression autodetect (${{ matrix.name }})"
@@ -192,6 +218,7 @@ jobs:
     # CMake build generates hdf5-config.cmake with imported targets that
     # reference ZLIB::ZLIB and/or szip-static in INTERFACE_LINK_LIBRARIES.
     - name: Build HDF5 with CMake
+      if: matrix.hdf5_build == 'cmake'
       run: |
         git clone https://github.com/HDFGroup/hdf5.git \
           --branch hdf5_${{ env.hdf5_vers }} --single-branch hdf5_src
@@ -214,10 +241,34 @@ jobs:
         cmake --install hdf5_build
       shell: bash
 
-    # Configure CGNS using HDF5_DIR (config-mode discovery).
+    # Build HDF5 from source with autotools.
+    # Autotools build produces h5cc with H5BLD_LIBS that the CGNS
+    # autotools configure parses to auto-detect zlib/szip dependencies.
+    - name: Build HDF5 with autotools
+      if: matrix.hdf5_build == 'autotools'
+      run: |
+        git clone https://github.com/HDFGroup/hdf5.git \
+          --branch hdf5_${{ env.hdf5_vers }} --single-branch hdf5_src
+        cd hdf5_src
+        ./configure \
+          --prefix=$HOME/hdf5 \
+          --disable-shared \
+          --enable-static \
+          --disable-fortran \
+          --disable-hl \
+          --disable-tests \
+          --disable-tools \
+          --disable-parallel \
+          --disable-nonstandard-feature-float16 \
+          ${{ matrix.zlib_at }} ${{ matrix.szip_at }}
+        make -j 4 install
+      shell: bash
+
+    # Configure CGNS using HDF5_DIR (config-mode discovery) for CMake-built HDF5.
     # HDF5_NEED_ZLIB and HDF5_NEED_SZIP are intentionally NOT set —
     # auto-detection from HDF5 target's INTERFACE_LINK_LIBRARIES must handle it.
-    - name: Configure CGNS
+    - name: Configure CGNS (CMake)
+      if: matrix.hdf5_build == 'cmake'
       run: |
         HDF5_CMAKE_DIR=$(dirname $(find $HOME/hdf5 -name "hdf5-config.cmake" | head -1))
         echo "Using HDF5_DIR=$HDF5_CMAKE_DIR"
@@ -231,12 +282,45 @@ jobs:
           -DHDF5_DIR=$HDF5_CMAKE_DIR
       shell: bash
 
-    - name: Build CGNS
+    - name: Build CGNS (CMake)
+      if: matrix.hdf5_build == 'cmake'
       run: cmake --build cbuild --config Debug --parallel 4
       shell: bash
 
-    - name: Test CGNS
+    - name: Test CGNS (CMake)
+      if: matrix.hdf5_build == 'cmake'
       run: |
         cd cbuild
         ctest -C Debug -VV --output-on-failure
+      shell: bash
+
+    # Configure CGNS using autotools for autotools-built HDF5.
+    # The configure script reads h5cc to auto-detect zlib/szip dependencies.
+    # --with-zlib and --with-szip are intentionally NOT passed to CGNS configure —
+    # auto-detection from HDF5's h5cc must handle it.
+    - name: Configure CGNS (autotools)
+      if: matrix.hdf5_build == 'autotools'
+      run: |
+        export FLIBS="-Wl,--no-as-needed -ldl"
+        export LIBS="-Wl,--no-as-needed -ldl"
+        cd src
+        ./configure \
+          --with-hdf5=$HOME/hdf5 \
+          --enable-lfs \
+          --disable-shared \
+          --enable-debug
+      shell: bash
+
+    - name: Build CGNS (autotools)
+      if: matrix.hdf5_build == 'autotools'
+      run: |
+        cd src
+        make -j 4
+      shell: bash
+
+    - name: Test CGNS (autotools)
+      if: matrix.hdf5_build == 'autotools'
+      run: |
+        cd src
+        make test
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 #  push:
 #  pull_request:
 env:
-  hdf5_vers: 2_0_0
+  hdf5_vers: 1_14_6
 
 # A workflow run is made up of one or more jobs that
 # can run sequentially or in parallel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,3 +153,90 @@ jobs:
 #    - name: Setup tmate session
 #      if: ${{ failure() }}
 #      uses: mxschmitt/action-tmate@v3
+
+  # Test auto-detection of HDF5 transitive compression dependencies (ZLIB, libaec/SZIP).
+  # Exercises the INTERFACE_LINK_LIBRARIES introspection in CMakeLists.txt that
+  # resolves ZLIB::ZLIB and szip/libaec targets without HDF5_NEED_ZLIB/SZIP flags.
+  test-hdf5-compression-autodetect:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "zlib-only"
+            zlib: ON
+            szip: OFF
+            apt_packages: "zlib1g-dev"
+          - name: "libaec-only"
+            zlib: OFF
+            szip: ON
+            apt_packages: "libaec-dev"
+          - name: "both"
+            zlib: ON
+            szip: ON
+            apt_packages: "zlib1g-dev libaec-dev"
+
+    name: "HDF5 compression autodetect (${{ matrix.name }})"
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'skip-ci')"
+
+    steps:
+    - name: Install compression libraries
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.apt_packages }}
+
+    - name: Get Sources
+      uses: actions/checkout@v3
+
+    # Build HDF5 from source with CMake to produce config-mode package files.
+    # CMake build generates hdf5-config.cmake with imported targets that
+    # reference ZLIB::ZLIB and/or szip-static in INTERFACE_LINK_LIBRARIES.
+    - name: Build HDF5 with CMake
+      run: |
+        git clone https://github.com/HDFGroup/hdf5.git \
+          --branch hdf5_${{ env.hdf5_vers }} --single-branch hdf5_src
+        cmake -S hdf5_src -B hdf5_build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=$HOME/hdf5 \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBUILD_STATIC_LIBS=ON \
+          -DHDF5_BUILD_TOOLS=OFF \
+          -DHDF5_BUILD_UTILS=OFF \
+          -DHDF5_BUILD_EXAMPLES=OFF \
+          -DBUILD_TESTING=OFF \
+          -DHDF5_BUILD_FORTRAN=OFF \
+          -DHDF5_BUILD_HL_LIB=OFF \
+          -DHDF5_ENABLE_PARALLEL=OFF \
+          -DHDF5_ENABLE_Z_LIB_SUPPORT=${{ matrix.zlib }} \
+          -DHDF5_ENABLE_SZIP_SUPPORT=${{ matrix.szip }} \
+          -DHDF5_ENABLE_SZIP_ENCODING=${{ matrix.szip }}
+        cmake --build hdf5_build --parallel 4
+        cmake --install hdf5_build
+      shell: bash
+
+    # Configure CGNS using HDF5_DIR (config-mode discovery).
+    # HDF5_NEED_ZLIB and HDF5_NEED_SZIP are intentionally NOT set —
+    # auto-detection from HDF5 target's INTERFACE_LINK_LIBRARIES must handle it.
+    - name: Configure CGNS
+      run: |
+        HDF5_CMAKE_DIR=$(dirname $(find $HOME/hdf5 -name "hdf5-config.cmake" | head -1))
+        echo "Using HDF5_DIR=$HDF5_CMAKE_DIR"
+        cmake -S . -B cbuild \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCGNS_BUILD_SHARED=OFF \
+          -DCGNS_ENABLE_HDF5=ON \
+          -DCGNS_ENABLE_TESTS=ON \
+          -DCGNS_ENABLE_FORTRAN=OFF \
+          -DCGNS_ENABLE_64BIT=ON \
+          -DHDF5_DIR=$HDF5_CMAKE_DIR
+      shell: bash
+
+    - name: Build CGNS
+      run: cmake --build cbuild --config Debug --parallel 4
+      shell: bash
+
+    - name: Test CGNS
+      run: |
+        cd cbuild
+        ctest -C Debug -VV --output-on-failure
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,7 @@ jobs:
           -DCGNS_ENABLE_HDF5=ON \
           -DCGNS_ENABLE_TESTS=ON \
           -DCGNS_ENABLE_FORTRAN=OFF \
-          -DCGNS_ENABLE_64BIT=ON \
+          -DCGNS_ENABLE_64BIT=OFF \
           -DHDF5_DIR=$HDF5_CMAKE_DIR
       shell: bash
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 #  push:
 #  pull_request:
 env:
-  hdf5_vers: 1_14_4
+  hdf5_vers: 2_0_0
 
 # A workflow run is made up of one or more jobs that
 # can run sequentially or in parallel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,6 +274,7 @@ jobs:
         echo "Using HDF5_DIR=$HDF5_CMAKE_DIR"
         cmake -S . -B cbuild \
           -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_INSTALL_PREFIX=$HOME/cgns_install \
           -DCGNS_BUILD_SHARED=OFF \
           -DCGNS_ENABLE_HDF5=ON \
           -DCGNS_ENABLE_TESTS=ON \
@@ -292,6 +293,49 @@ jobs:
       run: |
         cd cbuild
         ctest -C Debug -VV --output-on-failure
+      shell: bash
+
+    # Install CGNS and verify that a downstream project can consume it
+    # via find_package(cgns). This tests that cgns-config.cmake correctly
+    # resolves all transitive dependencies (HDF5, ZLIB, SZIP/libaec).
+    - name: Install CGNS (CMake)
+      if: matrix.hdf5_build == 'cmake'
+      run: cmake --install cbuild
+      shell: bash
+
+    - name: Test downstream find_package(cgns)
+      if: matrix.hdf5_build == 'cmake'
+      run: |
+        mkdir -p downstream_test && cd downstream_test
+        cat > test_cgns.c << 'CEOF'
+        #include <cgnslib.h>
+        #include <stdio.h>
+        int main() {
+            printf("CGNS version: %d\n", CGNS_VERSION);
+            int fn;
+            if (cg_open("test.cgns", CG_MODE_WRITE, &fn) == CG_OK) {
+                cg_close(fn);
+                printf("Successfully created and closed a CGNS file\n");
+                return 0;
+            }
+            printf("Failed to create CGNS file\n");
+            return 1;
+        }
+        CEOF
+        cat > CMakeLists.txt << 'CMEOF'
+        cmake_minimum_required(VERSION 3.20)
+        project(test_cgns C)
+        find_package(cgns REQUIRED)
+        add_executable(test_cgns test_cgns.c)
+        target_link_libraries(test_cgns PRIVATE CGNS::cgns_static)
+        CMEOF
+        HDF5_CMAKE_DIR=$(dirname $(find $HOME/hdf5 -name "hdf5-config.cmake" | head -1))
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DHDF5_DIR=$HDF5_CMAKE_DIR \
+          -Dcgns_DIR=$HOME/cgns_install/lib/cmake/cgns
+        cmake --build build --parallel 4
+        ./build/test_cgns
       shell: bash
 
     # Configure CGNS using autotools for autotools-built HDF5.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,11 +301,16 @@ jobs:
     - name: Configure CGNS (autotools)
       if: matrix.hdf5_build == 'autotools'
       run: |
+        export FC=gfortran
+        export F77=gfortran
+        export FCFLAGS="-fallow-argument-mismatch"
+        export FFLAGS="-fallow-argument-mismatch"
         export FLIBS="-Wl,--no-as-needed -ldl"
         export LIBS="-Wl,--no-as-needed -ldl"
         cd src
         ./configure \
           --with-hdf5=$HOME/hdf5 \
+          --with-fortran \
           --enable-lfs \
           --disable-shared \
           --enable-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,23 +339,39 @@ if (CGNS_ENABLE_HDF5)
     find_package(libaec QUIET)
     if (libaec_FOUND AND TARGET libaec::sz)
       # Extract library location from the imported target for legacy compatibility.
-      # Use the imported target to set SZIP_LIBRARY as a cache variable.
-      get_target_property(_sz_loc libaec::sz IMPORTED_LOCATION)
-      if (NOT _sz_loc)
-        # Try config-specific location if generic one is not set.
-        get_target_property(_libaec_configs libaec::sz IMPORTED_CONFIGURATIONS)
-        if (_libaec_configs)
-          list(GET _libaec_configs 0 _libaec_first_config)
-          string(TOUPPER "${_libaec_first_config}" _libaec_first_config)
-          get_target_property(_sz_loc libaec::sz IMPORTED_LOCATION_${_libaec_first_config})
+      # Try to resolve the specific config to avoid linking Release lib in Debug build.
+      get_target_property(_libaec_configs libaec::sz IMPORTED_CONFIGURATIONS)
+
+      set(_chosen_config "")
+      if (_libaec_configs)
+        # 1. Try to match the current CMAKE_BUILD_TYPE (if single-config generator)
+        if (CMAKE_BUILD_TYPE)
+          string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type_upper)
+          if (_build_type_upper IN_LIST _libaec_configs)
+            set(_chosen_config "${_build_type_upper}")
+          endif ()
         endif ()
+
+        # 2. If no match (or multi-config), fallback to the first available
+        if (NOT _chosen_config)
+          list(GET _libaec_configs 0 _chosen_config)
+        endif ()
+
+        get_target_property(_sz_loc libaec::sz IMPORTED_LOCATION_${_chosen_config})
       endif ()
+
+      # Fallback to config-agnostic IMPORTED_LOCATION
+      if (NOT _sz_loc)
+        get_target_property(_sz_loc libaec::sz IMPORTED_LOCATION)
+      endif ()
+
       if (_sz_loc)
         set(SZIP_LIBRARY "${_sz_loc}" CACHE FILEPATH "Path to szip library" FORCE)
       endif ()
       unset(_sz_loc)
       unset(_libaec_configs)
-      unset(_libaec_first_config)
+      unset(_chosen_config)
+      unset(_build_type_upper)
     endif ()
     # Fallback to finding the library directly
     if (NOT SZIP_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,9 @@ if (CGNS_ENABLE_HDF5)
     # Fallback to finding the library directly if find_package failed
     if (NOT ZLIB_FOUND)
       find_library(ZLIB_LIBRARY z)
+      if (NOT ZLIB_LIBRARY)
+        message(FATAL_ERROR "HDF5_NEED_ZLIB is ON but ZLIB was not found")
+      endif ()
     endif ()
     mark_as_advanced(CLEAR ZLIB_LIBRARY)
   else ()
@@ -339,6 +342,9 @@ if (CGNS_ENABLE_HDF5)
     find_package(libaec QUIET)
     if (libaec_FOUND AND TARGET libaec::sz)
       # Extract library location from the imported target for legacy compatibility.
+      # SZIP_LIBRARY must be a file path (not a target name) because downstream
+      # consumers use it with native_paths(), target_link_libraries(${SZIP_LIBRARY}),
+      # and other contexts that expect a path string.
       # Try to resolve the specific config to avoid linking Release lib in Debug build.
       get_target_property(_libaec_configs libaec::sz IMPORTED_CONFIGURATIONS)
 
@@ -463,10 +469,11 @@ if (CGNS_ENABLE_HDF5)
         find_package(ZLIB REQUIRED)
       endif ()
       # Detect SZIP/libaec in link interface — matches target names like
-      # szip-static, libaec::sz, $<LINK_ONLY:szip-static>, etc.
-      # Note: CMake regex does not support \b, so we use alternation instead.
-      # The string is normalized with ;-delimiters so ;sz; and ;sz- always work.
-      if (_hdf5_link_str MATCHES ";szip-|;sz;|;sz-|;libaec" AND NOT libaec_FOUND)
+      # szip-static, libaec::sz, $<LINK_ONLY:szip-static>, or bare sz/szip from
+      # older HDF5 installations. CMake regex does not support \b, so we use
+      # ;-delimited alternation. The string is normalized with leading/trailing
+      # semicolons so these patterns always match at element boundaries.
+      if (_hdf5_link_str MATCHES ";szip-|;szip;|;sz;|;sz-|;libaec" AND NOT libaec_FOUND)
         message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires SZIP, finding libaec package")
         find_package(libaec QUIET)
         if (NOT libaec_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,7 +463,7 @@ if (CGNS_ENABLE_HDF5)
       # szip-static, sz-shared, libaec::sz, $<LINK_ONLY:szip-static>, etc.
       # Note: CMake regex does not support \b, so we use alternation instead.
       # The string is normalized with ;-delimiters so ;sz; and ;sz- always work.
-      if (_hdf5_link_str MATCHES ";szip-|;sz;|;sz-|libaec" AND NOT libaec_FOUND)
+      if (_hdf5_link_str MATCHES ";szip-|;sz;|;sz-|;libaec" AND NOT libaec_FOUND)
         message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires SZIP, finding libaec package")
         find_package(libaec QUIET)
         if (NOT libaec_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,25 +446,26 @@ if (CGNS_ENABLE_HDF5)
     endif()
   endif ()
 
-  # If HDF5 needs ZLIB, a ZLIB::ZLIB target interface can pop up for hdf5
-  # Check the actual target's link interface to detect ZLIB dependency
-  if (TARGET hdf5-${CG_HDF5_LINK_TYPE})
-    get_target_property(_hdf5_link_libs hdf5-${CG_HDF5_LINK_TYPE} INTERFACE_LINK_LIBRARIES)
+  # When linking HDF5 statically, its compression dependencies (zlib, szip)
+  # must be explicitly resolved since they are not baked into a shared library.
+  # Check the actual target's link interface to detect these dependencies.
+  if (TARGET hdf5-static)
+    get_target_property(_hdf5_link_libs hdf5-static INTERFACE_LINK_LIBRARIES)
     if (_hdf5_link_libs)
       # Normalize with leading/trailing semicolons so delimited patterns always match
       set(_hdf5_link_str ";${_hdf5_link_libs};")
       # Detect ZLIB::ZLIB in link interface — matches both plain references
       # and generator expressions like $<LINK_ONLY:ZLIB::ZLIB>
       if (_hdf5_link_str MATCHES "ZLIB::ZLIB" AND NOT ZLIB_FOUND)
-        message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires ZLIB::ZLIB, finding ZLIB package")
+        message(STATUS "hdf5-static target requires ZLIB::ZLIB, finding ZLIB package")
         find_package(ZLIB REQUIRED)
       endif ()
       # Detect SZIP/libaec in link interface — matches target names like
-      # szip-static, sz-shared, libaec::sz, $<LINK_ONLY:szip-static>, etc.
+      # szip-static, libaec::sz, $<LINK_ONLY:szip-static>, etc.
       # Note: CMake regex does not support \b, so we use alternation instead.
       # The string is normalized with ;-delimiters so ;sz; and ;sz- always work.
       if (_hdf5_link_str MATCHES ";szip-|;sz;|;sz-|;libaec" AND NOT libaec_FOUND)
-        message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires SZIP, finding libaec package")
+        message(STATUS "hdf5-static target requires SZIP, finding libaec package")
         find_package(libaec QUIET)
         if (NOT libaec_FOUND)
           find_library(SZIP_LIBRARY NAMES szip sz)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,16 +321,46 @@ if (CGNS_ENABLE_HDF5)
   endif ()
 
   set(HDF5_NEED_ZLIB "OFF" CACHE BOOL "Does the HDF5 library require linking to zlib?")
-  if(HDF5_NEED_ZLIB)
-    find_library(ZLIB_LIBRARY z)
+  if (HDF5_NEED_ZLIB)
+    # Find ZLIB package to create ZLIB::ZLIB target for modern CMake compatibility
+    find_package(ZLIB QUIET)
+    # Fallback to finding the library directly if find_package failed
+    if (NOT ZLIB_FOUND)
+      find_library(ZLIB_LIBRARY z)
+    endif ()
     mark_as_advanced(CLEAR ZLIB_LIBRARY)
   else ()
     mark_as_advanced(FORCE ZLIB_LIBRARY)
-  endif()
+  endif ()
 
   set(HDF5_NEED_SZIP "OFF" CACHE BOOL "Does the HDF5 library require linking to szip?")
   if (HDF5_NEED_SZIP)
-    find_library(SZIP_LIBRARY NAMES szip sz)
+    # Try to find libaec package first for modern CMake compatibility
+    find_package(libaec QUIET)
+    if (libaec_FOUND AND TARGET libaec::sz)
+      # Extract library location from the imported target for legacy compatibility.
+      # Use the imported target to set SZIP_LIBRARY as a cache variable.
+      get_target_property(_sz_loc libaec::sz IMPORTED_LOCATION)
+      if (NOT _sz_loc)
+        # Try config-specific location if generic one is not set.
+        get_target_property(_libaec_configs libaec::sz IMPORTED_CONFIGURATIONS)
+        if (_libaec_configs)
+          list(GET _libaec_configs 0 _libaec_first_config)
+          string(TOUPPER "${_libaec_first_config}" _libaec_first_config)
+          get_target_property(_sz_loc libaec::sz IMPORTED_LOCATION_${_libaec_first_config})
+        endif ()
+      endif ()
+      if (_sz_loc)
+        set(SZIP_LIBRARY "${_sz_loc}" CACHE FILEPATH "Path to szip library" FORCE)
+      endif ()
+      unset(_sz_loc)
+      unset(_libaec_configs)
+      unset(_libaec_first_config)
+    endif ()
+    # Fallback to finding the library directly
+    if (NOT SZIP_LIBRARY)
+      find_library(SZIP_LIBRARY NAMES szip sz)
+    endif ()
     mark_as_advanced(CLEAR SZIP_LIBRARY)
   else ()
     mark_as_advanced(FORCE SZIP_LIBRARY)
@@ -389,29 +419,45 @@ if (CGNS_ENABLE_HDF5)
     # User provided information about HDF5 requirements.
     if (HDF5_NEED_ZLIB)
       set(HDF5_ENABLE_ZLIB_SUPPORT ON)
-      # Next line is ON just not to enter the following find_package(ZLIB)
-      # It is assumed that since we are faking a modern cmake
-      # The package search for ZLIB was done earlier.
+      # HDF5_PACKAGE_EXTLIBS ON prevents the check below from calling find_package(ZLIB)
+      # since we already called it above when HDF5_NEED_ZLIB was set
       set(HDF5_PACKAGE_EXTLIBS ON)
     endif()
     if (HDF5_NEED_SZIP)
       set(HDF5_ENABLE_SZIP_SUPPORT ON)
+      # Same for SZIP - we already attempted find_package(libaec) above
       set(HDF5_PACKAGE_EXTLIBS ON)
     endif()
   endif ()
 
-  # If HDF5 needs ZLIB, but ZLIB is an external package not provided by hdf5
-  # a ZLIB dependency should be added.
-  if (TARGET hdf5-static)
-    if (HDF5_ENABLE_ZLIB_SUPPORT AND NOT HDF5_PACKAGE_EXTLIBS)
-      message(STATUS "hdf5-static target needs ZLIB through an external library")
-      find_package(ZLIB)
+  # If HDF5 needs ZLIB, a ZLIB::ZLIB target interface can pop up for hdf5
+  # Check the actual target's link interface to detect ZLIB dependency
+  if (TARGET hdf5-${CG_HDF5_LINK_TYPE})
+    get_target_property(_hdf5_link_libs hdf5-${CG_HDF5_LINK_TYPE} INTERFACE_LINK_LIBRARIES)
+    if (_hdf5_link_libs)
+      # Normalize with leading/trailing semicolons so delimited patterns always match
+      set(_hdf5_link_str ";${_hdf5_link_libs};")
+      # Detect ZLIB::ZLIB in link interface — matches both plain references
+      # and generator expressions like $<LINK_ONLY:ZLIB::ZLIB>
+      if (_hdf5_link_str MATCHES "ZLIB::ZLIB" AND NOT ZLIB_FOUND)
+        message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires ZLIB::ZLIB, finding ZLIB package")
+        find_package(ZLIB REQUIRED)
+      endif ()
+      # Detect SZIP/libaec in link interface — matches target names like
+      # szip-static, sz-shared, libaec::sz, $<LINK_ONLY:szip-static>, etc.
+      # Note: CMake regex does not support \b, so we use alternation instead.
+      # The string is normalized with ;-delimiters so ;sz; and ;sz- always work.
+      if (_hdf5_link_str MATCHES ";szip-|;sz;|;sz-|libaec" AND NOT libaec_FOUND)
+        message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires SZIP, finding libaec package")
+        find_package(libaec QUIET)
+        if (NOT libaec_FOUND)
+          find_library(SZIP_LIBRARY NAMES szip sz)
+        endif ()
+      endif ()
     endif ()
-    if (HDF5_ENABLE_SZIP_SUPPORT AND NOT HDF5_PACKAGE_EXTLIBS)
-      message(STATUS "hdf5-static target needs SZIP through external libraries")
-      find_package(libaec)
-    endif()
-  endif()
+    unset(_hdf5_link_libs)
+    unset(_hdf5_link_str)
+  endif ()
 
 else ()
   mark_as_advanced(FORCE HDF5_NEED_ZLIB HDF5_NEED_SZIP HDF5_NEED_MPI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,8 +322,13 @@ if (CGNS_ENABLE_HDF5)
 
   set(HDF5_NEED_ZLIB "OFF" CACHE BOOL "Does the HDF5 library require linking to zlib?")
   if (HDF5_NEED_ZLIB)
-    # Find ZLIB package to create ZLIB::ZLIB target for modern CMake compatibility
-    find_package(ZLIB QUIET)
+    # Find ZLIB package to create ZLIB::ZLIB target for modern CMake compatibility.
+    # Use MODULE mode first since FindZLIB always creates ZLIB::ZLIB, whereas
+    # config-mode (ZLIBConfig.cmake) may export different target names.
+    find_package(ZLIB MODULE QUIET)
+    if (NOT ZLIB_FOUND)
+      find_package(ZLIB CONFIG QUIET)
+    endif ()
     # Fallback to finding the library directly if find_package failed.
     # Note: do not FATAL_ERROR here — ZLIB may be bundled with HDF5 (on any
     # platform when HDF5 is built with CMake). The auto-detection from HDF5's
@@ -345,12 +350,18 @@ if (CGNS_ENABLE_HDF5)
       # SZIP_LIBRARY must be a file path (not a target name) because downstream
       # consumers use it with native_paths(), target_link_libraries(${SZIP_LIBRARY}),
       # and other contexts that expect a path string.
-      # Try to resolve the specific config to avoid linking Release lib in Debug build.
+      # NOTE: This resolves to a single path at configure time.  On multi-config
+      # generators the build type is not known until build time, so linking the
+      # wrong configuration (e.g. Debug libaec against a Release build) can cause
+      # crashes on Windows due to C runtime mismatches.  Properly handling this
+      # would require generator expressions throughout the build system.
       get_target_property(_libaec_configs libaec::sz IMPORTED_CONFIGURATIONS)
 
       set(_chosen_config "")
       if (_libaec_configs)
-        # 1. Try to match the current CMAKE_BUILD_TYPE (if single-config generator)
+        list(LENGTH _libaec_configs _num_configs)
+
+        # 1. Try to match the current CMAKE_BUILD_TYPE (single-config generator)
         if (CMAKE_BUILD_TYPE)
           string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type_upper)
           if (_build_type_upper IN_LIST _libaec_configs)
@@ -358,12 +369,23 @@ if (CGNS_ENABLE_HDF5)
           endif ()
         endif ()
 
-        # 2. If no match (or multi-config), fallback to the first available
-        if (NOT _chosen_config)
+        # 2. Reject multi-config imports we cannot safely resolve
+        if (NOT _chosen_config AND _num_configs GREATER 1)
+          message(WARNING
+            "libaec::sz has multiple imported configurations (${_libaec_configs}) "
+            "and CMAKE_BUILD_TYPE is not set or does not match any of them. "
+            "Cannot safely choose a configuration at configure time. "
+            "Set CMAKE_BUILD_TYPE or provide a single-configuration libaec package.")
+        endif ()
+
+        # 3. Single config available — use it
+        if (NOT _chosen_config AND _num_configs EQUAL 1)
           list(GET _libaec_configs 0 _chosen_config)
         endif ()
 
-        get_target_property(_sz_loc libaec::sz IMPORTED_LOCATION_${_chosen_config})
+        if (_chosen_config)
+          get_target_property(_sz_loc libaec::sz IMPORTED_LOCATION_${_chosen_config})
+        endif ()
       endif ()
 
       # Fallback to config-agnostic IMPORTED_LOCATION
@@ -473,18 +495,21 @@ if (CGNS_ENABLE_HDF5)
         # Config-mode (ZLIBConfig.cmake from a CMake install of zlib) may export
         # different target names (ZLIB::zlib, ZLIB::zlibstatic) without ZLIB::ZLIB.
         find_package(ZLIB MODULE QUIET)
-        if (NOT TARGET ZLIB::ZLIB)
+        if (NOT ZLIB_FOUND)
           # Fallback to config-mode in case module mode failed
-          find_package(ZLIB QUIET)
+          find_package(ZLIB CONFIG QUIET)
         endif ()
         if (NOT TARGET ZLIB::ZLIB)
-          if (ZLIB_FOUND AND ZLIB_LIBRARIES)
-            # ZLIB was found (config-mode) but without ZLIB::ZLIB — create it
-            add_library(ZLIB::ZLIB UNKNOWN IMPORTED)
-            set_target_properties(ZLIB::ZLIB PROPERTIES
-              IMPORTED_LOCATION "${ZLIB_LIBRARIES}"
-              INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIRS}")
-          else ()
+          if (ZLIB_FOUND)
+            # ZLIB was found (config-mode) but without ZLIB::ZLIB — alias a
+            # known config-mode target so its properties are inherited correctly.
+            if (TARGET ZLIB::zlib)
+              add_library(ZLIB::ZLIB ALIAS ZLIB::zlib)
+            elseif (TARGET ZLIB::zlibstatic)
+              add_library(ZLIB::ZLIB ALIAS ZLIB::zlibstatic)
+            endif ()
+          endif ()
+          if (NOT TARGET ZLIB::ZLIB)
             message(FATAL_ERROR "hdf5-${CG_HDF5_LINK_TYPE} requires ZLIB::ZLIB but ZLIB was not found")
           endif ()
         endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,7 +469,25 @@ if (CGNS_ENABLE_HDF5)
       # creating the ZLIB::ZLIB imported target that HDF5's interface requires.
       if (_hdf5_link_str MATCHES "ZLIB::ZLIB" AND NOT TARGET ZLIB::ZLIB)
         message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires ZLIB::ZLIB, finding ZLIB package")
-        find_package(ZLIB REQUIRED)
+        # Try module mode first — CMake's FindZLIB always creates ZLIB::ZLIB.
+        # Config-mode (ZLIBConfig.cmake from a CMake install of zlib) may export
+        # different target names (ZLIB::zlib, ZLIB::zlibstatic) without ZLIB::ZLIB.
+        find_package(ZLIB MODULE QUIET)
+        if (NOT TARGET ZLIB::ZLIB)
+          # Fallback to config-mode in case module mode failed
+          find_package(ZLIB QUIET)
+        endif ()
+        if (NOT TARGET ZLIB::ZLIB)
+          if (ZLIB_FOUND AND ZLIB_LIBRARIES)
+            # ZLIB was found (config-mode) but without ZLIB::ZLIB — create it
+            add_library(ZLIB::ZLIB UNKNOWN IMPORTED)
+            set_target_properties(ZLIB::ZLIB PROPERTIES
+              IMPORTED_LOCATION "${ZLIB_LIBRARIES}"
+              INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIRS}")
+          else ()
+            message(FATAL_ERROR "hdf5-${CG_HDF5_LINK_TYPE} requires ZLIB::ZLIB but ZLIB was not found")
+          endif ()
+        endif ()
       endif ()
       # Detect SZIP/libaec in link interface — matches target names like
       # szip-static, libaec::sz, $<LINK_ONLY:szip-static>, or bare sz/szip from

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,7 +464,10 @@ if (CGNS_ENABLE_HDF5)
       set(_hdf5_link_str ";${_hdf5_link_libs};")
       # Detect ZLIB::ZLIB in link interface — matches both plain references
       # and generator expressions like $<LINK_ONLY:ZLIB::ZLIB>
-      if (_hdf5_link_str MATCHES "ZLIB::ZLIB" AND NOT ZLIB_FOUND)
+      # Check for the target explicitly rather than ZLIB_FOUND — a parent project
+      # may have called find_package(ZLIB) in legacy mode (variables only) without
+      # creating the ZLIB::ZLIB imported target that HDF5's interface requires.
+      if (_hdf5_link_str MATCHES "ZLIB::ZLIB" AND NOT TARGET ZLIB::ZLIB)
         message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires ZLIB::ZLIB, finding ZLIB package")
         find_package(ZLIB REQUIRED)
       endif ()
@@ -473,7 +476,8 @@ if (CGNS_ENABLE_HDF5)
       # older HDF5 installations. CMake regex does not support \b, so we use
       # ;-delimited alternation. The string is normalized with leading/trailing
       # semicolons so these patterns always match at element boundaries.
-      if (_hdf5_link_str MATCHES ";szip-|;szip;|;sz;|;sz-|;libaec" AND NOT libaec_FOUND)
+      # Check for the target explicitly rather than libaec_FOUND for the same reason.
+      if (_hdf5_link_str MATCHES ";szip-|;szip;|;sz;|;sz-|;libaec" AND NOT TARGET libaec::sz)
         message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires SZIP, finding libaec package")
         find_package(libaec QUIET)
         if (NOT libaec_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,12 +324,12 @@ if (CGNS_ENABLE_HDF5)
   if (HDF5_NEED_ZLIB)
     # Find ZLIB package to create ZLIB::ZLIB target for modern CMake compatibility
     find_package(ZLIB QUIET)
-    # Fallback to finding the library directly if find_package failed
+    # Fallback to finding the library directly if find_package failed.
+    # Note: do not FATAL_ERROR here — ZLIB may be bundled with HDF5 (on any
+    # platform when HDF5 is built with CMake). The auto-detection from HDF5's
+    # INTERFACE_LINK_LIBRARIES (further below) will resolve it.
     if (NOT ZLIB_FOUND)
       find_library(ZLIB_LIBRARY z)
-      if (NOT ZLIB_LIBRARY)
-        message(FATAL_ERROR "HDF5_NEED_ZLIB is ON but ZLIB was not found")
-      endif ()
     endif ()
     mark_as_advanced(CLEAR ZLIB_LIBRARY)
   else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,18 +446,20 @@ if (CGNS_ENABLE_HDF5)
     endif()
   endif ()
 
-  # When linking HDF5 statically, its compression dependencies (zlib, szip)
-  # must be explicitly resolved since they are not baked into a shared library.
-  # Check the actual target's link interface to detect these dependencies.
-  if (TARGET hdf5-static)
-    get_target_property(_hdf5_link_libs hdf5-static INTERFACE_LINK_LIBRARIES)
+  # Check the actual HDF5 target's link interface to detect compression dependencies.
+  # This inspects only the target we are actually linking against:
+  # - For hdf5-static: zlib/szip must be resolved explicitly (not baked in)
+  # - For hdf5-shared: normally no deps in interface, but handles broken configs
+  #   or Windows builds where ZLIB::ZLIB may still appear
+  if (TARGET hdf5-${CG_HDF5_LINK_TYPE})
+    get_target_property(_hdf5_link_libs hdf5-${CG_HDF5_LINK_TYPE} INTERFACE_LINK_LIBRARIES)
     if (_hdf5_link_libs)
       # Normalize with leading/trailing semicolons so delimited patterns always match
       set(_hdf5_link_str ";${_hdf5_link_libs};")
       # Detect ZLIB::ZLIB in link interface — matches both plain references
       # and generator expressions like $<LINK_ONLY:ZLIB::ZLIB>
       if (_hdf5_link_str MATCHES "ZLIB::ZLIB" AND NOT ZLIB_FOUND)
-        message(STATUS "hdf5-static target requires ZLIB::ZLIB, finding ZLIB package")
+        message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires ZLIB::ZLIB, finding ZLIB package")
         find_package(ZLIB REQUIRED)
       endif ()
       # Detect SZIP/libaec in link interface — matches target names like
@@ -465,7 +467,7 @@ if (CGNS_ENABLE_HDF5)
       # Note: CMake regex does not support \b, so we use alternation instead.
       # The string is normalized with ;-delimiters so ;sz; and ;sz- always work.
       if (_hdf5_link_str MATCHES ";szip-|;sz;|;sz-|;libaec" AND NOT libaec_FOUND)
-        message(STATUS "hdf5-static target requires SZIP, finding libaec package")
+        message(STATUS "hdf5-${CG_HDF5_LINK_TYPE} target requires SZIP, finding libaec package")
         find_package(libaec QUIET)
         if (NOT libaec_FOUND)
           find_library(SZIP_LIBRARY NAMES szip sz)

--- a/src/Test_UserGuideCode/C_code/CMakeLists.txt
+++ b/src/Test_UserGuideCode/C_code/CMakeLists.txt
@@ -92,7 +92,9 @@ if (CGNS_ENABLE_TESTS)
 		set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GROUP_NAME})
 		file(MAKE_DIRECTORY ${WORK_DIR})
 
-		# Copy OUTPUT reference files to build directory
+		# Copy OUTPUT reference files to build directory.
+		# Note: file(GLOB) is used here for data files, not sources. If new OUTPUT
+		# files are added to the source tree, re-run CMake to pick them up.
 		file(GLOB OUTPUT_FILES "${SRC_DIR}/OUTPUT*")
 		foreach(OUTPUT_FILE ${OUTPUT_FILES})
 			file(COPY ${OUTPUT_FILE} DESTINATION ${WORK_DIR})
@@ -133,7 +135,9 @@ if (CGNS_ENABLE_TESTS)
 		set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GROUP_NAME})
 		file(MAKE_DIRECTORY ${WORK_DIR})
 
-		# Copy OUTPUT reference files to build directory
+		# Copy OUTPUT reference files to build directory.
+		# Note: file(GLOB) is used here for data files, not sources. If new OUTPUT
+		# files are added to the source tree, re-run CMake to pick them up.
 		file(GLOB OUTPUT_FILES "${SRC_DIR}/OUTPUT*")
 		foreach(OUTPUT_FILE ${OUTPUT_FILES})
 			file(COPY ${OUTPUT_FILE} DESTINATION ${WORK_DIR})

--- a/src/Test_UserGuideCode/C_code/CMakeLists.txt
+++ b/src/Test_UserGuideCode/C_code/CMakeLists.txt
@@ -92,14 +92,6 @@ if (CGNS_ENABLE_TESTS)
 		set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GROUP_NAME})
 		file(MAKE_DIRECTORY ${WORK_DIR})
 
-		# Copy OUTPUT reference files to build directory.
-		# Note: file(GLOB) is used here for data files, not sources. If new OUTPUT
-		# files are added to the source tree, re-run CMake to pick them up.
-		file(GLOB OUTPUT_FILES "${SRC_DIR}/OUTPUT*")
-		foreach(OUTPUT_FILE ${OUTPUT_FILES})
-			file(COPY ${OUTPUT_FILE} DESTINATION ${WORK_DIR})
-		endforeach()
-
 		set(PREV_TEST "")
 		set(OUTPUT_NUM 1)
 		foreach(TEST_NAME ${WRITE_CHAIN})
@@ -120,7 +112,7 @@ if (CGNS_ENABLE_TESTS)
 			set_property(TEST C_code_${READ_TEST_NAME} PROPERTY COMMAND
 				${CMAKE_COMMAND}
 				-DTEST_PROGRAM=$<TARGET_FILE:${READ_TEST_NAME}>
-				-DREF_OUTPUT=${WORK_DIR}/OUTPUT${OUTPUT_NUM}
+				-DREF_OUTPUT=${SRC_DIR}/OUTPUT${OUTPUT_NUM}
 				-DWORK_DIR=${WORK_DIR}
 				-P ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_with_output_check.cmake)
 
@@ -134,14 +126,6 @@ if (CGNS_ENABLE_TESTS)
 		set(WORK_DIR ${CMAKE_CURRENT_BINARY_DIR}/${GROUP_NAME})
 		set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GROUP_NAME})
 		file(MAKE_DIRECTORY ${WORK_DIR})
-
-		# Copy OUTPUT reference files to build directory.
-		# Note: file(GLOB) is used here for data files, not sources. If new OUTPUT
-		# files are added to the source tree, re-run CMake to pick them up.
-		file(GLOB OUTPUT_FILES "${SRC_DIR}/OUTPUT*")
-		foreach(OUTPUT_FILE ${OUTPUT_FILES})
-			file(COPY ${OUTPUT_FILE} DESTINATION ${WORK_DIR})
-		endforeach()
 
 		# Create fixture setup test
 		add_test(NAME C_code_${GROUP_NAME}_setup COMMAND ${SETUP_EXE} WORKING_DIRECTORY ${WORK_DIR})
@@ -180,7 +164,7 @@ if (CGNS_ENABLE_TESTS)
 			set_property(TEST C_code_${READ_TEST_NAME} PROPERTY COMMAND
 				${CMAKE_COMMAND}
 				-DTEST_PROGRAM=$<TARGET_FILE:${READ_TEST_NAME}>
-				-DREF_OUTPUT=${WORK_DIR}/OUTPUT${OUTPUT_NUM}
+				-DREF_OUTPUT=${SRC_DIR}/OUTPUT${OUTPUT_NUM}
 				-DWORK_DIR=${WORK_DIR}
 				-P ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_with_output_check.cmake)
 

--- a/src/Test_UserGuideCode/Fortran_code/CMakeLists.txt
+++ b/src/Test_UserGuideCode/Fortran_code/CMakeLists.txt
@@ -93,14 +93,6 @@ if (CGNS_ENABLE_TESTS)
 		set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GROUP_NAME})
 		file(MAKE_DIRECTORY ${WORK_DIR})
 
-		# Copy OUTPUT reference files to build directory.
-		# Note: file(GLOB) is used here for data files, not sources. If new OUTPUT
-		# files are added to the source tree, re-run CMake to pick them up.
-		file(GLOB OUTPUT_FILES "${SRC_DIR}/OUTPUT*")
-		foreach(OUTPUT_FILE ${OUTPUT_FILES})
-			file(COPY ${OUTPUT_FILE} DESTINATION ${WORK_DIR})
-		endforeach()
-
 		set(PREV_TEST "")
 		set(OUTPUT_NUM 1)
 		foreach(TEST_NAME ${WRITE_CHAIN})
@@ -121,7 +113,7 @@ if (CGNS_ENABLE_TESTS)
 			set_property(TEST Fortran_code_${READ_TEST_NAME} PROPERTY COMMAND
 				${CMAKE_COMMAND}
 				-DTEST_PROGRAM=$<TARGET_FILE:${PREFIX}${READ_TEST_NAME}>
-				-DREF_OUTPUT=${WORK_DIR}/OUTPUT${OUTPUT_NUM}
+				-DREF_OUTPUT=${SRC_DIR}/OUTPUT${OUTPUT_NUM}
 				-DWORK_DIR=${WORK_DIR}
 				-P ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_with_output_check.cmake)
 
@@ -135,14 +127,6 @@ if (CGNS_ENABLE_TESTS)
 		set(WORK_DIR ${CMAKE_CURRENT_BINARY_DIR}/${GROUP_NAME})
 		set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GROUP_NAME})
 		file(MAKE_DIRECTORY ${WORK_DIR})
-
-		# Copy OUTPUT reference files to build directory.
-		# Note: file(GLOB) is used here for data files, not sources. If new OUTPUT
-		# files are added to the source tree, re-run CMake to pick them up.
-		file(GLOB OUTPUT_FILES "${SRC_DIR}/OUTPUT*")
-		foreach(OUTPUT_FILE ${OUTPUT_FILES})
-			file(COPY ${OUTPUT_FILE} DESTINATION ${WORK_DIR})
-		endforeach()
 
 		# Create fixture setup test
 		add_test(NAME Fortran_code_${GROUP_NAME}_setup COMMAND ${PREFIX}${SETUP_EXE} WORKING_DIRECTORY ${WORK_DIR})
@@ -181,7 +165,7 @@ if (CGNS_ENABLE_TESTS)
 			set_property(TEST Fortran_code_${READ_TEST_NAME} PROPERTY COMMAND
 				${CMAKE_COMMAND}
 				-DTEST_PROGRAM=$<TARGET_FILE:${PREFIX}${READ_TEST_NAME}>
-				-DREF_OUTPUT=${WORK_DIR}/OUTPUT${OUTPUT_NUM}
+				-DREF_OUTPUT=${SRC_DIR}/OUTPUT${OUTPUT_NUM}
 				-DWORK_DIR=${WORK_DIR}
 				-P ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_with_output_check.cmake)
 

--- a/src/Test_UserGuideCode/Fortran_code/CMakeLists.txt
+++ b/src/Test_UserGuideCode/Fortran_code/CMakeLists.txt
@@ -93,7 +93,9 @@ if (CGNS_ENABLE_TESTS)
 		set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GROUP_NAME})
 		file(MAKE_DIRECTORY ${WORK_DIR})
 
-		# Copy OUTPUT reference files to build directory
+		# Copy OUTPUT reference files to build directory.
+		# Note: file(GLOB) is used here for data files, not sources. If new OUTPUT
+		# files are added to the source tree, re-run CMake to pick them up.
 		file(GLOB OUTPUT_FILES "${SRC_DIR}/OUTPUT*")
 		foreach(OUTPUT_FILE ${OUTPUT_FILES})
 			file(COPY ${OUTPUT_FILE} DESTINATION ${WORK_DIR})
@@ -134,7 +136,9 @@ if (CGNS_ENABLE_TESTS)
 		set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GROUP_NAME})
 		file(MAKE_DIRECTORY ${WORK_DIR})
 
-		# Copy OUTPUT reference files to build directory
+		# Copy OUTPUT reference files to build directory.
+		# Note: file(GLOB) is used here for data files, not sources. If new OUTPUT
+		# files are added to the source tree, re-run CMake to pick them up.
 		file(GLOB OUTPUT_FILES "${SRC_DIR}/OUTPUT*")
 		foreach(OUTPUT_FILE ${OUTPUT_FILES})
 			file(COPY ${OUTPUT_FILE} DESTINATION ${WORK_DIR})

--- a/src/Test_UserGuideCode/run_test_with_output_check.cmake
+++ b/src/Test_UserGuideCode/run_test_with_output_check.cmake
@@ -30,11 +30,11 @@ execute_process(
   WORKING_DIRECTORY "${WORK_DIR}"
   RESULT_VARIABLE TEST_RESULT
   OUTPUT_VARIABLE TEST_OUTPUT
-  ERROR_QUIET
+  ERROR_VARIABLE TEST_STDERR
 )
 
 if(NOT TEST_RESULT EQUAL 0)
-  message(FATAL_ERROR "Test program failed with exit code ${TEST_RESULT}")
+  message(FATAL_ERROR "Test program failed with exit code ${TEST_RESULT}\nstderr:\n${TEST_STDERR}")
 endif()
 
 # Read reference output file
@@ -46,6 +46,8 @@ file(READ "${REF_OUTPUT}" REF_CONTENT)
 
 # Function to filter output lines (remove Library lines)
 function(filter_output INPUT_STR OUTPUT_VAR)
+  # Escape semicolons before splitting so they are not treated as list separators
+  string(REPLACE ";" "\\;" INPUT_STR "${INPUT_STR}")
   # Split into lines
   string(REGEX REPLACE "\r?\n" ";" LINES "${INPUT_STR}")
 

--- a/src/cgns-config.cmake.in
+++ b/src/cgns-config.cmake.in
@@ -106,6 +106,38 @@ if (${CGNS_PACKAGE_NAME}_ENABLE_HDF5_SUPPORT)
       endif()
     endif()
   endif()
+
+  # Auto-detect compression dependencies from HDF5 target's link interface.
+  # This mirrors the build-time logic in CMakeLists.txt and handles cases where:
+  # - HDF5 config-mode targets reference ZLIB::ZLIB or szip targets that need
+  #   resolution on the consumer's system
+  # - Legacy module-mode fallback targets contain raw library paths
+  # - HDF5 bundles compression libs (any platform) and provides them via its
+  #   own config-mode package
+  set(_cgns_hdf5_target "hdf5-${${CGNS_PACKAGE_NAME}_HDF5_LINK_TYPE}")
+  if (TARGET ${_cgns_hdf5_target})
+    get_target_property(_hdf5_link_libs ${_cgns_hdf5_target} INTERFACE_LINK_LIBRARIES)
+    if (_hdf5_link_libs)
+      set(_hdf5_link_str ";${_hdf5_link_libs};")
+      # Detect ZLIB::ZLIB in link interface — matches both plain references
+      # and generator expressions like $<LINK_ONLY:ZLIB::ZLIB>
+      if (_hdf5_link_str MATCHES "ZLIB::ZLIB" AND NOT TARGET ZLIB::ZLIB)
+        find_dependency(ZLIB)
+      endif ()
+      # Detect SZIP/libaec in link interface — matches target names like
+      # szip-static, libaec::sz, $<LINK_ONLY:szip-static>, or bare sz/szip
+      # from older HDF5 installations.
+      if (_hdf5_link_str MATCHES ";szip-|;szip;|;sz;|;sz-|;libaec" AND NOT TARGET libaec::sz)
+        find_package(libaec QUIET)
+        if (NOT libaec_FOUND)
+          find_library(SZIP_LIBRARY NAMES szip sz)
+        endif ()
+      endif ()
+    endif ()
+    unset(_hdf5_link_libs)
+    unset(_hdf5_link_str)
+  endif ()
+  unset(_cgns_hdf5_target)
 endif()
 #-----------------------------------------------------------------------------
 # Don't include targets if this file is being picked up by another

--- a/src/cgns-config.cmake.in
+++ b/src/cgns-config.cmake.in
@@ -122,7 +122,23 @@ if (${CGNS_PACKAGE_NAME}_ENABLE_HDF5_SUPPORT)
       # Detect ZLIB::ZLIB in link interface — matches both plain references
       # and generator expressions like $<LINK_ONLY:ZLIB::ZLIB>
       if (_hdf5_link_str MATCHES "ZLIB::ZLIB" AND NOT TARGET ZLIB::ZLIB)
-        find_dependency(ZLIB)
+        # Try module mode first — CMake's FindZLIB always creates ZLIB::ZLIB.
+        # Config-mode (ZLIBConfig.cmake from a CMake install of zlib) may export
+        # different target names (ZLIB::zlib, ZLIB::zlibstatic) without ZLIB::ZLIB.
+        find_package(ZLIB MODULE QUIET)
+        if (NOT TARGET ZLIB::ZLIB)
+          find_package(ZLIB QUIET)
+        endif ()
+        if (NOT TARGET ZLIB::ZLIB AND ZLIB_FOUND AND ZLIB_LIBRARIES)
+          # ZLIB was found (config-mode) but without ZLIB::ZLIB — create it
+          add_library(ZLIB::ZLIB UNKNOWN IMPORTED)
+          set_target_properties(ZLIB::ZLIB PROPERTIES
+            IMPORTED_LOCATION "${ZLIB_LIBRARIES}"
+            INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIRS}")
+        endif ()
+        if (NOT TARGET ZLIB::ZLIB)
+          message(FATAL_ERROR "CGNS requires ZLIB::ZLIB (via HDF5) but ZLIB was not found")
+        endif ()
       endif ()
       # Detect SZIP/libaec in link interface — matches target names like
       # szip-static, libaec::sz, $<LINK_ONLY:szip-static>, or bare sz/szip

--- a/src/cgns-config.cmake.in
+++ b/src/cgns-config.cmake.in
@@ -126,15 +126,17 @@ if (${CGNS_PACKAGE_NAME}_ENABLE_HDF5_SUPPORT)
         # Config-mode (ZLIBConfig.cmake from a CMake install of zlib) may export
         # different target names (ZLIB::zlib, ZLIB::zlibstatic) without ZLIB::ZLIB.
         find_package(ZLIB MODULE QUIET)
-        if (NOT TARGET ZLIB::ZLIB)
-          find_package(ZLIB QUIET)
+        if (NOT ZLIB_FOUND)
+          find_package(ZLIB CONFIG QUIET)
         endif ()
-        if (NOT TARGET ZLIB::ZLIB AND ZLIB_FOUND AND ZLIB_LIBRARIES)
-          # ZLIB was found (config-mode) but without ZLIB::ZLIB — create it
-          add_library(ZLIB::ZLIB UNKNOWN IMPORTED)
-          set_target_properties(ZLIB::ZLIB PROPERTIES
-            IMPORTED_LOCATION "${ZLIB_LIBRARIES}"
-            INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIRS}")
+        if (NOT TARGET ZLIB::ZLIB AND ZLIB_FOUND)
+          # ZLIB was found (config-mode) but without ZLIB::ZLIB — alias a
+          # known config-mode target so its properties are inherited correctly.
+          if (TARGET ZLIB::zlib)
+            add_library(ZLIB::ZLIB ALIAS ZLIB::zlib)
+          elseif (TARGET ZLIB::zlibstatic)
+            add_library(ZLIB::ZLIB ALIAS ZLIB::zlibstatic)
+          endif ()
         endif ()
         if (NOT TARGET ZLIB::ZLIB)
           message(FATAL_ERROR "CGNS requires ZLIB::ZLIB (via HDF5) but ZLIB was not found")

--- a/src/examples/fortran/CMakeLists.txt
+++ b/src/examples/fortran/CMakeLists.txt
@@ -93,21 +93,6 @@ endforeach()
 
 # Add CTest integration for regression testing
 if (CGNS_ENABLE_TESTS)
-  # Copy OUTPUT reference files to build directory
-  foreach(ENTRY ${EXAMPLE_PROGRAMS})
-    # Parse directory name
-    string(REPLACE "|" ";" ENTRY_PARTS ${ENTRY})
-    list(GET ENTRY_PARTS 0 DIR_AND_PROGRAMS)
-    string(REPLACE ":" ";" DIR_PARTS ${DIR_AND_PROGRAMS})
-    list(GET DIR_PARTS 0 DIR)
-
-    # Copy OUTPUT reference file if it exists
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${DIR}/OUTPUT")
-      file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/${DIR}/OUTPUT"
-           DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/${DIR}")
-    endif()
-  endforeach()
-
   # Add individual test for each example directory
   foreach(ENTRY ${EXAMPLE_PROGRAMS})
     # Parse "directory:program1,program2,...|write_prog|read_prog"
@@ -138,8 +123,9 @@ if (CGNS_ENABLE_TESTS)
       set(READ_EXE "")
     endif()
 
-    # Reference OUTPUT file path
-    set(REF_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${DIR}/OUTPUT")
+    # Reference OUTPUT file path — read directly from source tree so edits
+    # take effect without re-running CMake
+    set(REF_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${DIR}/OUTPUT")
 
     # Work directory for test execution
     set(WORK_DIR "${CMAKE_CURRENT_BINARY_DIR}/${DIR}")

--- a/src/examples/fortran/run_fortran_example_test.cmake
+++ b/src/examples/fortran/run_fortran_example_test.cmake
@@ -36,11 +36,11 @@ execute_process(
   WORKING_DIRECTORY "${WORK_DIR}"
   RESULT_VARIABLE WRITE_RESULT
   OUTPUT_QUIET
-  ERROR_QUIET
+  ERROR_VARIABLE WRITE_STDERR
 )
 
 if(NOT WRITE_RESULT EQUAL 0)
-  message(FATAL_ERROR "Write program failed with exit code ${WRITE_RESULT}")
+  message(FATAL_ERROR "Write program failed with exit code ${WRITE_RESULT}\nstderr:\n${WRITE_STDERR}")
 endif()
 
 # Execute read program and capture output
@@ -50,11 +50,11 @@ execute_process(
   WORKING_DIRECTORY "${WORK_DIR}"
   RESULT_VARIABLE READ_RESULT
   OUTPUT_VARIABLE READ_OUTPUT
-  ERROR_QUIET
+  ERROR_VARIABLE READ_STDERR
 )
 
 if(NOT READ_RESULT EQUAL 0)
-  message(FATAL_ERROR "Read program failed with exit code ${READ_RESULT}")
+  message(FATAL_ERROR "Read program failed with exit code ${READ_RESULT}\nstderr:\n${READ_STDERR}")
 endif()
 
 # Read reference output file
@@ -66,6 +66,8 @@ file(READ "${REF_OUTPUT}" REF_CONTENT)
 
 # Function to filter output lines (remove Library, DonorDatatype, datatype= lines)
 function(filter_output INPUT_STR OUTPUT_VAR)
+  # Escape semicolons before splitting so they are not treated as list separators
+  string(REPLACE ";" "\\;" INPUT_STR "${INPUT_STR}")
   # Split into lines
   string(REGEX REPLACE "\r?\n" ";" LINES "${INPUT_STR}")
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -177,10 +177,10 @@ if (CGNS_ENABLE_FORTRAN)
 	# Both test64f.F90 and test64f_f03.F90 use fixed-form syntax despite .F90 extension
 	if (CGNS_ENABLE_64BIT)
 	  add_executable( test64f ${test64f_FILES} )
-	  set_source_files_properties(test64f.F90 PROPERTIES Fortran_FORMAT FIXED)
+	  set_source_files_properties(${test64f_FILES} PROPERTIES Fortran_FORMAT FIXED)
 
 	  add_executable( test64f_f03 ${test64f_f03_FILES} )
-	  set_source_files_properties(test64f_f03.F90 PROPERTIES Fortran_FORMAT FIXED)
+	  set_source_files_properties(${test64f_f03_FILES} PROPERTIES Fortran_FORMAT FIXED)
 	endif()
 #	if (NOT CGNS_ENABLE_64BIT)
 # Don't build the F77 source because they will fail if ENABLE_64BIT is used


### PR DESCRIPTION
Fixes build failure when linking against hdf5-static where the
ZLIB::ZLIB or SZIP imported targets referenced in HDF5's link
interface were not found. The fix introspects the HDF5 target's
INTERFACE_LINK_LIBRARIES to auto-detect and resolve transitive
compression dependencies (ZLIB, SZIP/libaec). Adds new action for testing.

Fixes #932
----
<!-- ELLIPSIS_HIDDEN -->
> [!IMPORTANT]
> Improved HDF5 transitive dependency detection by refactoring CMake to inspect HDF5's link interface instead of relying on build flags, and added a GitHub Actions workflow to test auto-detection with various compression library configurations.
> 
>   - **CMake Dependency Detection**:
>     - Updated ZLIB and SZIP/libaec detection to use `find_package()` first with fallback to `find_library()` for legacy compatibility.
>     - Refactored HDF5 dependency detection to inspect the `INTERFACE_LINK_LIBRARIES` property of the HDF5 target instead of relying on `HDF5_ENABLE_ZLIB_SUPPORT` and `HDF5_ENABLE_SZIP_SUPPORT` flags.
>     - Added pattern matching logic to detect `ZLIB::ZLIB` and SZIP/libaec targets in HDF5's link interface, including support for generator expressions.
>     - Replaced hardcoded `hdf5-static` target reference with dynamic `hdf5-${CG_HDF5_LINK_TYPE}` target.
>     - Updated comments to clarify the purpose of `HDF5_PACKAGE_EXTLIBS` and explain the new dependency detection approach.
>     - Improved code consistency by standardizing spacing in conditional statements.
>   - **GitHub Actions Workflow**:
>     - Added new workflow job to test auto-detection of HDF5 transitive compression dependencies with a matrix strategy covering three configurations: zlib-only, libaec-only, and both compression libraries enabled.
>     - Workflow builds HDF5 from source with specified compression support options and configures CGNS without explicitly setting compression flags to verify automatic dependency resolution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=CGNS%2FCGNS&utm_source=github&utm_medium=referral)<sup> for c63dfc64732973d27cc9a0a6c1f5bf87a5a6875d. You can [customize](https://app.ellipsis.dev/CGNS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>
<!-- ELLIPSIS_HIDDEN -->