### PR TITLE
fix(parallel): cgp_coord_multi_read_data should require READ, not WRITE

### DIFF
--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -3266,6 +3266,11 @@ int cgp_coord_multi_read_data(int fn, int B, int Z, int *C, const cgsize_t *rmin
     status = readwrite_multi_data_parallel(nsets, dset_id, mem_type_id, mem_space_id, file_space_id, &Data,
                                          zone->index_dim, rmin, rmax, CG_PAR_READ);
 
+  free(dset_id);
+  free(mem_type_id);
+  free(mem_space_id);
+  free(file_space_id);
+
   return status;
 
  error:
@@ -3371,6 +3376,11 @@ int cgp_coord_multi_write_data(int fn, int B, int Z, int *C, const cgsize_t *rmi
     Data.u.wbuf = buf;
     status =  readwrite_multi_data_parallel(nsets, dset_id, mem_type_id, mem_space_id, file_space_id, &Data,
                                             zone->index_dim, rmin, rmax, CG_PAR_WRITE);
+
+    free(dset_id);
+    free(mem_type_id);
+    free(mem_space_id);
+    free(file_space_id);
 
     return status;
 
@@ -3680,6 +3690,11 @@ int cgp_particle_coord_multi_read_data(int fn, int B, int P, int *C, const cgsiz
     status = readwrite_multi_data_parallel(nsets, dset_id, mem_type_id, mem_space_id, file_space_id, &Data,
                                            1, rmin, rmax, CG_PAR_READ);
 
+  free(dset_id);
+  free(mem_type_id);
+  free(mem_space_id);
+  free(file_space_id);
+
   return status;
 
  error:
@@ -3782,6 +3797,11 @@ int cgp_particle_coord_multi_write_data(int fn, int B, int P, int *C, const cgsi
     Data.u.wbuf = buf;
     status =  readwrite_multi_data_parallel(nsets, dset_id, mem_type_id, mem_space_id, file_space_id, &Data,
                                             1, rmin, rmax, CG_PAR_WRITE);
+
+    free(dset_id);
+    free(mem_type_id);
+    free(mem_space_id);
+    free(file_space_id);
 
     return status;
 

--- a/src/pcgnslib.c
+++ b/src/pcgnslib.c
@@ -3225,7 +3225,7 @@ int cgp_coord_multi_read_data(int fn, int B, int Z, int *C, const cgsize_t *rmin
     cg = cgi_get_file(fn);
     if (check_parallel(cg)) return CG_ERROR;
 
-    if (cgi_check_mode(cg->filename, cg->mode, CG_MODE_WRITE))
+    if (cgi_check_mode(cg->filename, cg->mode, CG_MODE_READ))
       goto error;
 
     dset_id = (hid_t *)malloc(nsets*sizeof(hid_t));


### PR DESCRIPTION
`cgp_coord_multi_read_data()` verifies that the file is in WRITE mode when it should verify that it's in READ mode.

Also fixed some memory leaks in the `multi` routines.