### PR TITLE
Expose missing C constants in Fortran and fix typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(GNUInstallDirs)
 
 # Determine CGNS_VERSION from src/cgns_version.h for
 file (READ ${PROJECT_SOURCE_DIR}/src/cgns_version.h _cgnslib_h_contents)
-string (REGEX REPLACE ".*#define[ \t]+CGNS_DOTVERS[ \t]+([0-9]*)\\.([0-9])[0-9]*.*$"
+string (REGEX REPLACE ".*#define[ \t]+CGNS_DOTVERS_VALUE[ \t]+([0-9]*)\\.([0-9])[0-9]*.*$"
     "\\1.\\2" CGNS_VERSION ${_cgnslib_h_contents})
 
 set(CGNS_PACKAGE "cgns")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ project("cgns" C)
 
 include(GNUInstallDirs)
 
-# Determine CGNS_VERSION from src/cgnslib.h for 
-file (READ ${PROJECT_SOURCE_DIR}/src/cgnslib.h _cgnslib_h_contents)
+# Determine CGNS_VERSION from src/cgns_version.h for
+file (READ ${PROJECT_SOURCE_DIR}/src/cgns_version.h _cgnslib_h_contents)
 string (REGEX REPLACE ".*#define[ \t]+CGNS_DOTVERS[ \t]+([0-9]*)\\.([0-9])[0-9]*.*$"
     "\\1.\\2" CGNS_VERSION ${_cgnslib_h_contents})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -717,6 +717,7 @@ install (TARGETS ${install_targets}
 # Set the install path of the header files
 set(headers
   cgnslib.h
+  cgns_version.h
   cgns_io.h
   cgnswin_f.h
   ${CMAKE_CURRENT_BINARY_DIR}/cgnsconfig.h

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -123,6 +123,7 @@ install-cgns : $(CGNSLIB) $(INCLUDEDIR) $(LIBDIR) @INSTALLPCGNS@ @INSTALLADF@
 	$(INSTALL_DATA) cgnstypes_f.h $(INCLUDEDIR)/cgnstypes_f.h
 	$(INSTALL_DATA) cgnstypes_f03.h $(INCLUDEDIR)/cgnstypes_f03.h
 	$(INSTALL_DATA) cgnslib.h $(INCLUDEDIR)/cgnslib.h
+	$(INSTALL_DATA) cgns_version.h $(INCLUDEDIR)/cgns_version.h
 	$(INSTALL_DATA) cgnswin_f.h $(INCLUDEDIR)/cgnswin_f.h
 	$(INSTALL_DATA) cgns_io.h $(INCLUDEDIR)/cgns_io.h
 	$(INSTALL_DATA) cgnsconfig.h $(INCLUDEDIR)/cgnsconfig.h
@@ -181,6 +182,7 @@ uninstall :
 	-$(RM) $(INCLUDEDIR)/cgnstypes.h
 	-$(RM) $(INCLUDEDIR)/cgnstypes_f.h
 	-$(RM) $(INCLUDEDIR)/cgnslib.h
+	-$(RM) $(INCLUDEDIR)/cgns_version.h
 	-$(RM) $(INCLUDEDIR)/cgnswin_f.h
 	-$(RM) $(INCLUDEDIR)/cgns_io.h
 	-$(RM) $(INCLUDEDIR)/cgnsconfig.h
@@ -234,7 +236,7 @@ $(OBJDIR)/cg_malloc.$(O) : cg_malloc.c cg_malloc.h
 $(OBJDIR)/cgns_f.$(O) : cgns_f.F90 cgnstypes_f.h
 	$(F77) $(FOPTS_MOD) $(COOUT)$@ -c cgns_f.F90
 
-cgnslib.h : cgnstypes.h
+cgnslib.h : cgnstypes.h cgns_version.h
 cgns_header.h : cgnstypes.h
 cgns_io.h : cgnstypes.h
 

--- a/src/cgnsKeywords.h
+++ b/src/cgnsKeywords.h
@@ -63,10 +63,7 @@ freely, subject to the following restrictions:
  *      VERSION NUMBER                                                   *
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-#define CGNS_VERSION 5000
-#define CGNS_DOTVERS 5.00
-#define CGNS_COMPATVERSION 2540
-#define CGNS_COMPATDOTVERS 2.54
+#include "cgns_version.h"
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
  *      modes for cgns file                                              *

--- a/src/cgns_f.F90
+++ b/src/cgns_f.F90
@@ -41,6 +41,12 @@ MODULE cgns
   IMPLICIT NONE
 
 #include "cgnstypes_f03.h"
+#include "cgns_version.h"
+! Undef the public macros so they do not collide with the PARAMETER names below
+#undef CGNS_VERSION
+#undef CGNS_DOTVERS
+#undef CGNS_COMPATVERSION
+#undef CGNS_COMPATDOTVERS
 
 !These definitions are needed for Windows DLLs
 !DEC$ IF DEFINED(WINNT)
@@ -205,7 +211,7 @@ MODULE cgns
   INTEGER(C_INT), PARAMETER :: CG_ERROR           = 1
   INTEGER(C_INT), PARAMETER :: CG_NODE_NOT_FOUND  = 2
   INTEGER(C_INT), PARAMETER :: CG_INCORRECT_PATH  = 3
-  INTEGER(C_INT), PARAMETER :: CG_CG_NO_INDEX_DIM = 4
+  INTEGER(C_INT), PARAMETER :: CG_NO_INDEX_DIM    = 4
 
   !* legacy code support
   INTEGER(C_INT) ALL_OK, ERROR, NODE_NOT_FOUND, INCORRECT_PATH
@@ -219,7 +225,7 @@ MODULE cgns
 !DEC$ATTRIBUTES DLLEXPORT :: CG_ERROR
 !DEC$ATTRIBUTES DLLEXPORT :: CG_NODE_NOT_FOUND
 !DEC$ATTRIBUTES DLLEXPORT :: CG_INCORRECT_PATH
-!DEC$ATTRIBUTES DLLEXPORT :: CG_CG_NO_INDEX_DIM
+!DEC$ATTRIBUTES DLLEXPORT :: CG_NO_INDEX_DIM
 !DEC$endif
 
 !* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
@@ -252,6 +258,26 @@ MODULE cgns
   INTEGER(C_INT), PARAMETER :: CG_CONFIG_RIND_ZERO = 0
   INTEGER(C_INT), PARAMETER :: CG_CONFIG_RIND_CORE = 1
 
+!* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
+!*      Max goto depth (found in cgnslib.h)                            *
+!* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
+  INTEGER(C_INT), PARAMETER :: CG_MAX_GOTO_DEPTH = 20
+
+!* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
+!*      HDF5 dataset storage layout (found in cgnslib.h)               *
+!* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
+  INTEGER(C_INT), PARAMETER :: CG_CONTIGUOUS = 0
+  INTEGER(C_INT), PARAMETER :: CG_COMPACT    = 1
+  INTEGER(C_INT), PARAMETER :: CG_CHUNKED    = 2
+
+!* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
+!*      CGNS version constants (from cgns_version.h)                   *
+!* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
+  INTEGER, PARAMETER :: CGNS_VERSION       = CGNS_VERSION_VALUE
+  REAL,    PARAMETER :: CGNS_DOTVERS       = CGNS_DOTVERS_VALUE
+  INTEGER, PARAMETER :: CGNS_COMPATVERSION = CGNS_COMPATVERSION_VALUE
+  REAL,    PARAMETER :: CGNS_COMPATDOTVERS = CGNS_COMPATDOTVERS_VALUE
+
 !DEC$if defined(BUILD_CGNS_DLL)
 !DEC$ATTRIBUTES DLLEXPORT :: CG_CONFIG_ERROR
 !DEC$ATTRIBUTES DLLEXPORT :: CG_CONFIG_COMPRESS
@@ -276,6 +302,17 @@ MODULE cgns
 
 !DEC$ATTRIBUTES DLLEXPORT :: CG_CONFIG_RIND_ZERO
 !DEC$ATTRIBUTES DLLEXPORT :: CG_CONFIG_RIND_CORE
+
+!DEC$ATTRIBUTES DLLEXPORT :: CG_MAX_GOTO_DEPTH
+
+!DEC$ATTRIBUTES DLLEXPORT :: CG_CONTIGUOUS
+!DEC$ATTRIBUTES DLLEXPORT :: CG_COMPACT
+!DEC$ATTRIBUTES DLLEXPORT :: CG_CHUNKED
+
+!DEC$ATTRIBUTES DLLEXPORT :: CGNS_VERSION
+!DEC$ATTRIBUTES DLLEXPORT :: CGNS_DOTVERS
+!DEC$ATTRIBUTES DLLEXPORT :: CGNS_COMPATVERSION
+!DEC$ATTRIBUTES DLLEXPORT :: CGNS_COMPATDOTVERS
 !DEC$endif
 
   !* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
@@ -465,7 +502,7 @@ MODULE cgns
 !* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
 !*      Governing Equations and Physical Models Types                  *
 !* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
-  CHARACTER(LEN=MAX_LEN) :: GoverningEquationsTypeName(0:7)
+  CHARACTER(LEN=MAX_LEN) :: GoverningEquationsTypeName(0:8)
   ENUM, BIND(C)
     ENUMERATOR :: CGNS_ENUMV(GoverningEquationsNull)        = CG_Null
     ENUMERATOR :: CGNS_ENUMV(GoverningEquationsUserDefined) = CG_UserDefined
@@ -475,6 +512,7 @@ MODULE cgns
     ENUMERATOR :: CGNS_ENUMV(NSTurbulent)                   = 5
     ENUMERATOR :: CGNS_ENUMV(NSLaminarIncompressible)       = 6
     ENUMERATOR :: CGNS_ENUMV(NSTurbulentIncompressible)     = 7
+    ENUMERATOR :: CGNS_ENUMV(LatticeBoltzmann)              = 8
   END ENUM
 
 !DEC$if defined(BUILD_CGNS_DLL)
@@ -578,7 +616,7 @@ MODULE cgns
 !** ParticleBreakupModel_t: KelvinHelmholtz, KelvinHelmholtzACT, RayleighTaylor,
 !**    KelvinHelmholtzRayleighTaylor, TAB, ETAB, LISA, SHF, PilchErdman, ReitzDiwakar
 !**
-!** ParticleForceModel_t: Sphere, NonShpere, Tracer, BeetstraVanDerHoefKuipers,
+!** ParticleForceModel_t: Sphere, NonSphere, Tracer, BeetstraVanDerHoefKuipers,
 !**     Ergun, CliftGrace, Gidaspow, HaiderLevenspiel, PlessisMasliyah,
 !**     SyamlalOBrien, SaffmanMei, TennetiGargSubramaniam, Tomiyama, Stokes,
 !**     StokesCunningham, WenYu
@@ -617,7 +655,7 @@ MODULE cgns
     ENUMERATOR :: CGNS_ENUMV(PilchErdman)                            = 23
     ENUMERATOR :: CGNS_ENUMV(ReitzDiwakar)                           = 24
     ENUMERATOR :: CGNS_ENUMV(Sphere)                                 = 25
-    ENUMERATOR :: CGNS_ENUMV(NonShpere)                              = 26
+    ENUMERATOR :: CGNS_ENUMV(NonSphere)                              = 26
     ENUMERATOR :: CGNS_ENUMV(Tracer)                                 = 27
     ENUMERATOR :: CGNS_ENUMV(BeetstraVanDerHoefKuipers)              = 28
     ENUMERATOR :: CGNS_ENUMV(Ergun)                                  = 29
@@ -955,7 +993,8 @@ MODULE cgns
 
   DATA GoverningEquationsTypeName / 'Null','UserDefined', &
     'FullPotential','Euler', 'NSLaminar', 'NSTurbulent', &
-    'NSLaminarIncompressible', 'NSTurbulentIncompressible'/
+    'NSLaminarIncompressible', 'NSTurbulentIncompressible', &
+    'LatticeBoltzmann'/
 
   DATA ModelTypeName / 'Null','UserDefined', &
     'Ideal','VanderWaals', 'Constant','PowerLaw', &
@@ -983,7 +1022,7 @@ MODULE cgns
     'HertzKuwabaraKono', 'ORourke', 'Stochastic', 'NonStochastic', &
     'NTC', 'KelvinHelmholtz', 'KelvinHelmholtzACT', 'RayleighTaylor', &
     'KelvinHelmholtzRayleighTaylor', 'ReitzKHRT', 'TAB', 'ETAB', &
-    'LISA', 'SHF', 'PilchErdman', 'ReitzDiwakar', 'Sphere', 'NonShpere', &
+    'LISA', 'SHF', 'PilchErdman', 'ReitzDiwakar', 'Sphere', 'NonSphere', &
     'Tracer', 'BeetstraVanDerHoefKuipers', 'Ergun', 'CliftGrace', &
     'Gidaspow', 'HaiderLevenspiel', 'PlessisMasliyah', &
     'SyamlalOBrien', 'SaffmanMei', 'TennetiGargSubramaniam', 'Tomiyama', &

--- a/src/cgns_version.h
+++ b/src/cgns_version.h
@@ -1,0 +1,29 @@
+/* ------------------------------------------------------------------------- *
+ * CGNS - CFD General Notation System (http://www.cgns.org)                  *
+ * CGNS/MLL - Mid-Level Library header file                                  *
+ * ------------------------------------------------------------------------- */
+
+/* Single source of truth for CGNS version numbers.
+ * Included by cgnslib.h, cgnsKeywords.h, and cgns_f.F90.
+ * Uses only #define with numeric literals so it is valid
+ * for both C and Fortran preprocessing.
+ *
+ * The _VALUE macros hold the raw numbers.  The public macros
+ * (CGNS_VERSION, etc.) are aliases used by C code.  Fortran
+ * #undefs the public macros and creates typed PARAMETERs from
+ * the _VALUE macros so both languages share a single value.   */
+
+#ifndef CGNS_VERSION_H
+#define CGNS_VERSION_H
+
+#define CGNS_VERSION_VALUE       5000
+#define CGNS_DOTVERS_VALUE       5.00
+#define CGNS_COMPATVERSION_VALUE 2540
+#define CGNS_COMPATDOTVERS_VALUE 2.54
+
+#define CGNS_VERSION       CGNS_VERSION_VALUE
+#define CGNS_DOTVERS       CGNS_DOTVERS_VALUE
+#define CGNS_COMPATVERSION CGNS_COMPATVERSION_VALUE
+#define CGNS_COMPATDOTVERS CGNS_COMPATDOTVERS_VALUE
+
+#endif

--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -17165,7 +17165,7 @@ int cg_particle_governing_write(CGNS_ENUMT(ParticleGoverningEquationsType_t) Par
  *                                 LinearSpringDashpot, Pair, HertzMindlin, HertzKuwabaraKono, ORourke, Stochastic, NonStochastic, NTC
  *	ParticleBreakupModel_t		     CG_Null, CG_UserDefined, KelvinHelmholtz, KelvinHelmholtzACT, RayleighTaylor,
  *                                 KelvinHelmholtzRayleighTaylor, ReitzKHRT, TAB, ETAB, LISA, SHF, PilchErdman, ReitzDiwakar
- *	ParticleForceModel_t		        CG_Null, CG_UserDefined, Sphere, NonShpere, Tracer, BeetstraVanDerHoefKuipers, Ergun,
+ *	ParticleForceModel_t		        CG_Null, CG_UserDefined, Sphere, NonSphere, Tracer, BeetstraVanDerHoefKuipers, Ergun,
  *                                 CliftGrace, Gidaspow, HaiderLevenspiel, PlessisMasliyah, SyamlalOBrien, SaffmanMei,
  *                                 TennetiGargSubramaniam, Tomiyama, Stokes, StokesCunningham, WenYu
  *	ParticleWallInteractionModel_t  CG_Null, CG_UserDefined, Linear, NonLinear, HardSphere, SoftSphere,
@@ -17210,7 +17210,7 @@ int cg_particle_model_read(const char *ModelLabel, CGNS_ENUMT(ParticleModelType_
  *                                 Pair, HertzMindlin, HertzKuwabaraKono, ORourke, Stochastic, NonStochastic, NTC
  *	ParticleBreakupModel_t		     CG_Null, CG_UserDefined, KelvinHelmholtz, KelvinHelmholtzACT, RayleighTaylor,
  *                                 KelvinHelmholtzRayleighTaylor, ReitzKHRT, TAB, ETAB, LISA, SHF, PilchErdman, ReitzDiwakar
- *	ParticleForceModel_t		        CG_Null, CG_UserDefined, Sphere, NonShpere, Tracer, BeetstraVanDerHoefKuipers, Ergun,
+ *	ParticleForceModel_t		        CG_Null, CG_UserDefined, Sphere, NonSphere, Tracer, BeetstraVanDerHoefKuipers, Ergun,
  *                                 CliftGrace, Gidaspow, HaiderLevenspiel, PlessisMasliyah, SyamlalOBrien, SaffmanMei,
  *                                 TennetiGargSubramaniam, Tomiyama, Stokes, StokesCunningham, WenYu
  *	ParticleWallInteractionModel_t  CG_Null, CG_UserDefined, Linear, NonLinear, HardSphere, SoftSphere,

--- a/src/cgnslib.h
+++ b/src/cgnslib.h
@@ -45,11 +45,7 @@
 #ifndef CGNSLIB_H
 #define CGNSLIB_H
 
-#define CGNS_VERSION 5000
-#define CGNS_DOTVERS 5.00
-
-#define CGNS_COMPATVERSION 2540
-#define CGNS_COMPATDOTVERS 2.54
+#include "cgns_version.h"
 
 #include "cgnstypes.h"
 
@@ -616,7 +612,7 @@ typedef enum {
 ** ParticleBreakupModel_t: KelvinHelmholtz, KelvinHelmholtzACT, RayleighTaylor,
 **    KelvinHelmholtzRayleighTaylor, TAB, ETAB, LISA, SHF, PilchErdman, ReitzDiwakar
 **
-** ParticleForceModel_t: Sphere, NonShpere, Tracer, BeetstraVanDerHoefKuipers,
+** ParticleForceModel_t: Sphere, NonSphere, Tracer, BeetstraVanDerHoefKuipers,
 **     Ergun, CliftGrace, Gidaspow, HaiderLevenspiel, PlessisMasliyah,
 **     SyamlalOBrien, SaffmanMei, TennetiGargSubramaniam, Tomiyama, Stokes,
 **     StokesCunningham, WenYu


### PR DESCRIPTION
- Add missing Fortran parameters: CG_MAX_GOTO_DEPTH, CG_CONTIGUOUS, CG_COMPACT, CG_CHUNKED, CGNS_VERSION, CGNS_DOTVERS, CGNS_COMPATVERSION, CGNS_COMPATDOTVERS
- Add missing LatticeBoltzmann enumerator to GoverningEquationsType_t
- Fix CG_CG_NO_INDEX_DIM typo to CG_NO_INDEX_DIM
- Fix NonShpere typo to NonSphere in enums, data arrays, and comments
- Consolidate version constants into cgns_version.h shared by C and Fortran
- Update CMake and autotools to install cgns_version.h