### PR TITLE
ci: add workflow_dispatch trigger to main and intel workflows

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -5,11 +5,12 @@
 name: Intel
 permissions: read-all
 
-on: 
+on:
   push:
     branches: [ develop, master ]
   pull_request:
     branches: [ develop, master ]
+  workflow_dispatch:
 
 env:
   # Update urls accordingly for oneapi found at:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,12 @@ name: cgns
 
 # Controls when the action will run. 
 #Triggers the workflow on push or pull requests.
-on: 
+on:
   push:
     branches: [ develop, master ]
   pull_request:
     branches: [ develop, master ]
+  workflow_dispatch:
 #on: 
 #  push:
 #  pull_request:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `main.yml` and `intel.yml` so CI can be manually triggered on any branch from the GitHub Actions UI.

## Motivation
Patch release branches (e.g. `release/v4.5.2`) are not covered by the existing `push`/`pull_request` triggers which are limited to `develop` and `master`. `workflow_dispatch` allows running the full CI suite on these branches on demand.