### PR TITLE
fix(ci): enable SonarQube PR analysis mode for pull requests

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -97,9 +97,19 @@ jobs:
           gcovr -r .. --sonarqube --exclude-unreachable-branches --exclude-throw-branches > coverage.xml
         shell: bash
 
+      - name: Set SonarQube analysis parameters
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "SONAR_EXTRA_ARGS=-Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+          else
+            echo "SONAR_EXTRA_ARGS=-Dsonar.branch.name=${{ github.ref_name }}" >> $GITHUB_ENV
+          fi
+
       - name: Run SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: >
-            -Dsonar.branch.name=${{ github.ref_name }}
+            ${{ env.SONAR_EXTRA_ARGS }}
             -Dsonar.cfamily.compile-commands=cbuild/${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json


### PR DESCRIPTION
Switch from branch analysis to PR-specific parameters when triggered by a pull_request event, so SonarQube reports only new issues in the PR diff. Add GITHUB_TOKEN for PR decoration comments.