### PR TITLE
fix: resolve CodeQL format specifier and overflow warnings in cgnslib.c

### DIFF
--- a/src/cgnslib.c
+++ b/src/cgnslib.c
@@ -7063,7 +7063,7 @@ int cg_elements_general_write(int fn, int B, int Z, int S,
             cgi_error("Error in allocation size for new ParentElements data");
             return CG_ERROR;
         }
-        newelems = (cgsize_t *)malloc((size_t)(cnt * newsize * sizeof(cgsize_t)));
+        newelems = (cgsize_t *)malloc((size_t)cnt * (size_t)newsize * sizeof(cgsize_t));
         if (NULL == newelems) {
             cgi_error("Error allocating new ParentElements data");
             return CG_ERROR;
@@ -10259,7 +10259,7 @@ int cg_conn_write(int fn, int B, int Z,  const char * connectname,
     }
     if (!(ptset_type==CGNS_ENUMV(PointRange) && npnts==2) &&
         !(ptset_type==CGNS_ENUMV(PointList) && npnts>0)) {
-        cgi_error("Invalid input:  npoint=%ld, point set type=%s",
+        cgi_error("Invalid input:  npoint=%" PRIdCGSIZE ", point set type=%s",
                npnts, PointSetTypeName[ptset_type]);
         return CG_ERROR;
     }
@@ -10873,11 +10873,11 @@ int cg_1to1_write(int fn, int B, int Z, const char * connectname,
     index_dim = zone->index_dim;
     for (i=0; i<index_dim; i++) {   /* can't check donorrange because it may not yet be written */
         if (range[i]<=0 || range[i+index_dim]>zone->nijk[i]) {
-            cgi_error("Invalid input range:  %ld->%ld",range[i], range[i+index_dim]);
+            cgi_error("Invalid input range:  %" PRIdCGSIZE "->%" PRIdCGSIZE, range[i], range[i+index_dim]);
             return CG_ERROR;
         }
         if (abs(transform[i])>index_dim) {
-            cgi_error("Invalid transformation index: %d.  The indices must all be between 1 and %ld",i, index_dim);
+            cgi_error("Invalid transformation index: %d.  The indices must all be between 1 and %" PRIdCGSIZE, i, index_dim);
             return CG_ERROR;
         }
         if (transform[i] != 0) {
@@ -10886,7 +10886,7 @@ int cg_1to1_write(int fn, int B, int Z, const char * connectname,
         dr = range[i+index_dim] - range[i];
         ddr = donor_range[j+index_dim] - donor_range[j];
         if (dr != ddr && dr != -ddr) {
-                cgi_error("Invalid input:  range = %ld->%ld and donor_range = %ld->%ld",
+                cgi_error("Invalid input:  range = %" PRIdCGSIZE "->%" PRIdCGSIZE " and donor_range = %" PRIdCGSIZE "->%" PRIdCGSIZE,
                 range[i], range[i+index_dim], donor_range[j], donor_range[j+index_dim]);
                 return CG_ERROR;
             }
@@ -11313,7 +11313,7 @@ int cg_boco_write(int fn, int B, int Z, const char * boconame,
           ptype == CGNS_ENUMV(ElementList)) && npnts <= 0) ||
         ((ptype == CGNS_ENUMV(PointRange) ||
           ptype == CGNS_ENUMV(ElementRange)) && npnts != 2)) {
-        cgi_error("Invalid input:  npoint=%ld, point set type=%s",
+        cgi_error("Invalid input:  npoint=%" PRIdCGSIZE ", point set type=%s",
                    npnts, PointSetTypeName[ptype]);
         return CG_ERROR;
     }
@@ -17788,7 +17788,7 @@ int cg_array_write(const char * ArrayName, CGNS_ENUMT(DataType_t) DataType,
     }
     for (n=0; n<DataDimension; n++) {
         if (DimensionVector[n]<=0) {
-            cgi_error("Invalid array size: %ld",DimensionVector[n]);
+            cgi_error("Invalid array size: %" PRIdCGSIZE, DimensionVector[n]);
             return CG_ERROR;
         }
     }
@@ -17904,7 +17904,7 @@ int cg_array_general_write(const char *arrayname,
 
     for (n=0; n<s_numdim; n++) {
         if (s_dimvals[n] < 1) {
-            cgi_error("Invalid array dimension for file: %ld", s_dimvals[n]);
+            cgi_error("Invalid array dimension for file: %" PRIdCGSIZE, s_dimvals[n]);
             return CG_ERROR;
         }
     }
@@ -20008,20 +20008,20 @@ int cg_ptset_write(CGNS_ENUMT(PointSetType_t) ptset_type, cgsize_t npnts,
 
      /* verify input */
     if(npnts == 0 || pnts == NULL) {
-    cgi_error("Invalid input:  npoint=%ld, point set type=%s",
+    cgi_error("Invalid input:  npoint=%" PRIdCGSIZE ", point set type=%s",
                    npnts, PointSetTypeName[ptset_type]);
         return CG_ERROR;
     }
 
     if (ptset_type == CGNS_ENUMV(PointList)) {
         if (npnts <= 0) {
-            cgi_error("Invalid input:  npoint=%ld, point set type=%s",
+            cgi_error("Invalid input:  npoint=%" PRIdCGSIZE ", point set type=%s",
                    npnts, PointSetTypeName[ptset_type]);
             return CG_ERROR;
         }
     } else if (ptset_type == CGNS_ENUMV(PointRange)) {
         if (npnts != 2) {
-            cgi_error("Invalid input:  npoint=%ld, point set type=%s",
+            cgi_error("Invalid input:  npoint=%" PRIdCGSIZE ", point set type=%s",
                    npnts, PointSetTypeName[ptset_type]);
             return CG_ERROR;
         }


### PR DESCRIPTION
Replace %ld format specifiers for cgsize_t arguments with the project's PRIdCGSIZE macro, which expands correctly for both 32-bit ("d") and 64-bit (PRId64) builds. Also fix a potential integer overflow in the ParentElements malloc call by casting cnt and newsize to size_t before multiplication.