### PR TITLE
fix(ci): make Windows CGNS Tools workflow resilient to VS version bumps

### DIFF
--- a/.github/workflows/windows-tools.yml
+++ b/.github/workflows/windows-tools.yml
@@ -26,7 +26,18 @@ jobs:
         $version = "8.6.15"
         $buildRoot = "$env:TEMP\tcltk_build"
         $installDir = "C:\tcltk"
-        $vcvarsall = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"
+
+        # Locate vcvarsall.bat dynamically since the VS version/edition on
+        # GitHub-hosted Windows runners can change (e.g. 2022 -> 2026).
+        $vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+        $vsInstallPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if (-not $vsInstallPath) {
+            throw "Could not locate a Visual Studio installation with the VC tools component"
+        }
+        $vcvarsall = Join-Path $vsInstallPath "VC\Auxiliary\Build\vcvarsall.bat"
+        if (-not (Test-Path $vcvarsall)) {
+            throw "vcvarsall.bat not found at $vcvarsall"
+        }
 
         # Download and extract Tcl/Tk source
         Write-Host "Downloading Tcl/Tk..."
@@ -114,7 +125,10 @@ jobs:
         # Configure CGNS with HDF5 and cgnstools
         $hdf5CmakeDir = "$env:USERPROFILE\hdf5\cmake"
 
-        cmake -G "Visual Studio 17 2022" -A x64 `
+        # Let CMake auto-detect the installed Visual Studio generator
+        # instead of hardcoding a version, since the VS version bundled
+        # on GitHub-hosted Windows runners changes over time.
+        cmake -A x64 `
           -DCMAKE_BUILD_TYPE=Release `
           -DCGNS_ENABLE_FORTRAN=OFF `
           -DCGNS_ENABLE_HDF5=ON `


### PR DESCRIPTION
## Summary
- The Windows CGNS Tools workflow ([windows-tools.yml](https://github.com/CGNS/CGNS/actions/runs/28403194702/job/84159331607?pr=962)) started failing because GitHub's `windows-latest` runner image moved to a VS2026-only image, and the workflow hardcoded a VS2022 path to `vcvarsall.bat`.
- Locate `vcvarsall.bat` dynamically via `vswhere.exe` instead of a hardcoded VS2022 Enterprise path.
- Drop the hardcoded `-G "Visual Studio 17 2022"` CMake generator and let CMake auto-detect the installed VS generator, since only VS2026 is present on the current runner image and no VS2022.

## Test plan
- [ ] Confirm the "Windows Latest - CGNS Tools" CI job passes on this PR