### PR TITLE
fix(ci): skip SonarQube scan on Dependabot pull requests

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -14,12 +14,14 @@ jobs:
   sonarqube:
     name: SonarQube Scan
     runs-on: ubuntu-latest
-    # Only run on push events or same-repository PRs from a non-Dependabot actor.
-    # Forks cannot access secrets, so this prevents the workflow from failing.
-    # GitHub also withholds secrets from pull_request runs triggered by Dependabot,
-    # even for same-repo branches, so those must be excluded explicitly too.
+    # Only run on push events to the upstream repo, or same-repository PRs
+    # from a non-Dependabot actor. Forks cannot access secrets (SONAR_TOKEN
+    # is only configured on CGNS/CGNS), so this prevents the workflow from
+    # failing on forks. GitHub also withholds secrets from pull_request runs
+    # triggered by Dependabot, even for same-repo branches, so those must be
+    # excluded explicitly too.
     if: |
-      github.event_name == 'push' ||
+      (github.event_name == 'push' && github.repository == 'CGNS/CGNS') ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.actor != 'dependabot[bot]')

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -14,11 +14,15 @@ jobs:
   sonarqube:
     name: SonarQube Scan
     runs-on: ubuntu-latest
-    # Only run on push events or PRs from the same repository (not forks)
-    # Forks cannot access secrets, so this prevents the workflow from failing
+    # Only run on push events or same-repository PRs from a non-Dependabot actor.
+    # Forks cannot access secrets, so this prevents the workflow from failing.
+    # GitHub also withholds secrets from pull_request runs triggered by Dependabot,
+    # even for same-repo branches, so those must be excluded explicitly too.
     if: |
       github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
## Summary
- The SonarQube Analysis workflow's fork guard only checks `head.repo.full_name`, which passes for Dependabot PRs since their branches live in the same repository.
- GitHub Actions withholds repository secrets from `pull_request`-triggered runs whose actor is `dependabot[bot]` regardless of that check, so `SONAR_TOKEN` comes through empty and the scan fails with "Not authorized or project not found" (exit code 3).

Adds an explicit `github.actor != 'dependabot[bot]'` condition alongside the existing fork check, so the job is skipped (not failed) for Dependabot PRs, consistent with how forks are already handled.