### PR TITLE
fix(ptests): use STATIC library for shared Fortran test utils (#968)

### DIFF
--- a/src/ptests/CMakeLists.txt
+++ b/src/ptests/CMakeLists.txt
@@ -80,7 +80,7 @@ if (CGNS_ENABLE_FORTRAN AND HAVE_FORTRAN_2003)
     test_general_wrappers_f90
     ftest_zone
   )
-  add_library(test_utilsf OBJECT ${CMAKE_SOURCE_DIR}/src/tests/utilsf.F90)
+  add_library(test_utilsf STATIC ${CMAKE_SOURCE_DIR}/src/tests/utilsf.F90)
 
   function (add_fortran_exe file)
     add_executable (${file} ${file}.F90)


### PR DESCRIPTION
## Summary
- Addresses #968 — ninja fails with `multiple rules generate src/ptests/testing_utils.mod` on newer CMake/gfortran (e.g. Fedora Rawhide), while Unix Makefiles builds fine.
- `test_utilsf` was an `OBJECT` library compiling `src/tests/utilsf.F90` (which defines `module testing_utils`), linked into 8 separate Fortran ptests executables in the same directory. CMake's own notes on Fortran module support flag this shape — an OBJECT library's module consumed across target boundaries — as a fragile case for the Ninja generator's dyndep handling.
- Switching to `STATIC` removes the ambiguity: consumers link the compiled archive rather than each having their own build edge tied to the shared `.mod` file.

## Verification
- Could not reproduce the reported ninja error locally (tried CMake 3.31.10 and 4.4.0, Ninja 1.13.2, gfortran 15.2.0 on macOS) — likely depends on the specific CMake/gfortran versions on Fedora Rawhide.
- Confirmed a clean Ninja build still succeeds with this change, and the affected parallel Fortran tests (`pcgns_ftest`, `ftest_zone`) still pass at runtime.
- This fix is based on a plausible, well-documented root cause, not a direct repro — @opoplawski, could you confirm on your end whether this resolves the ninja build failure?