### PR TITLE
Fix tools_install_dir typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,9 @@ if(WIN32)
   set(tools_install_suffix "")
 endif()
 
-set(CGNS_INSTALL_TOOLS_BINDIR "${CMAKE_INSTALL_BINDIR}${install_suffix}" CACHE PATH
+set(CGNS_INSTALL_TOOLS_BINDIR "${CMAKE_INSTALL_BINDIR}${tools_install_suffix}" CACHE PATH
     "CGNS: tools binary install location")
-set(CGNS_INSTALL_TOOLS_DATADIR "${CMAKE_INSTALL_DATADIR}${install_suffix}" CACHE PATH
+set(CGNS_INSTALL_TOOLS_DATADIR "${CMAKE_INSTALL_DATADIR}${tools_install_suffix}" CACHE PATH
     "CGNS: arch independent tools data install location")
 
 set(CGNS_BUILD_SHARED "ON" CACHE BOOL "Build a shared version of the library")


### PR DESCRIPTION
Seems like a simple typo from looking at https://github.com/CGNS/CGNS/commit/3678074139c3668d0ce5091cb998619cae7ef504#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a