### PR TITLE
Fix build on i686

### DIFF
--- a/src/ptests/test_poly_unstructured_f90.F90
+++ b/src/ptests/test_poly_unstructured_f90.F90
@@ -56,7 +56,7 @@ PROGRAM test_poly_unstructured_f
   INTEGER(cgsize_t) :: nbCellWrite
   INTEGER(cgsize_t) :: nbNodeWrite
   INTEGER(cgsize_t), TARGET :: start, end
-  INTEGER(C_INT64_T) :: start_l, end_l, nb_read
+  INTEGER(cgsize_t) :: start_l, end_l, nb_read
   INTEGER(cgsize_t) :: iNode, jNode, iCell, jCell, i, j, k
   INTEGER(cgsize_t) :: local_size(1)
   INTEGER(cgsize_t) :: sizes(3)


### PR DESCRIPTION
Without this, the build fails on i686 with:
```
[448/746] /usr/lib/mpich/bin/mpifort -I/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests -I/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/tests -I/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/i686-redhat-linux-gnu-mpich/src -I/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src -I/usr/include/mpich-i386 -I/usr/include -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m32 -march=i686 -mtune=generic -msse2 -mfpmath=sse -mstackrealign -fasynchronous-unwind-tables -fstack-clash-protection -mtls-dialect=gnu -I/usr/lib/gfortran/modules -fallow-argument-mismatch -DNO_CONCATENATION -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m32 -march=i686 -mtune=generic -msse2 -mfpmath=sse -mstackrealign -fasynchronous-unwind-tables -fstack-clash-protection -mtls-dialect=gnu -I /usr/lib/gfortran/modules/mpich -Jsrc/ptests -fpreprocessed -c src/ptests/CMakeFiles/test_poly_unstructured_f90.dir/test_poly_unstructured_f90.F90-pp.f90 -o src/ptests/CMakeFiles/test_poly_unstructured_f90.dir/test_poly_unstructured_f90.F90.o
FAILED: [code=1] src/ptests/CMakeFiles/test_poly_unstructured_f90.dir/test_poly_unstructured_f90.F90.o 
/usr/lib/mpich/bin/mpifort -I/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests -I/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/tests -I/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/i686-redhat-linux-gnu-mpich/src -I/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src -I/usr/include/mpich-i386 -I/usr/include -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m32 -march=i686 -mtune=generic -msse2 -mfpmath=sse -mstackrealign -fasynchronous-unwind-tables -fstack-clash-protection -mtls-dialect=gnu -I/usr/lib/gfortran/modules -fallow-argument-mismatch -DNO_CONCATENATION -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m32 -march=i686 -mtune=generic -msse2 -mfpmath=sse -mstackrealign -fasynchronous-unwind-tables -fstack-clash-protection -mtls-dialect=gnu -I /usr/lib/gfortran/modules/mpich -Jsrc/ptests -fpreprocessed -c src/ptests/CMakeFiles/test_poly_unstructured_f90.dir/test_poly_unstructured_f90.F90-pp.f90 -o src/ptests/CMakeFiles/test_poly_unstructured_f90.dir/test_poly_unstructured_f90.F90.o
f951: Warning: -D_FORTIFY_SOURCE not defined
f951: Warning: -D_GLIBCXX_ASSERTIONS not defined
/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests/test_poly_unstructured_f90.F90:356:21:
  356 |            DO iCell = start_l, end_l
      |                     1
Warning: Possible change of value in conversion from INTEGER(8) to INTEGER(4) at (1) [-Wconversion]
/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests/test_poly_unstructured_f90.F90:356:30:
  356 |            DO iCell = start_l, end_l
      |                              1
Warning: Possible change of value in conversion from INTEGER(8) to INTEGER(4) at (1) [-Wconversion]
/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests/test_poly_unstructured_f90.F90:420:99:
  420 |      CALL cgp_poly_elements_read_data_offsets_f(F, B, iZone, S, start_l, end_l, offsets_read, ierr)
      |                                                                                                   1
Error: Type mismatch in argument ‘start’ at (1); passed INTEGER(8) to INTEGER(4)
/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests/test_poly_unstructured_f90.F90:420:99:
  420 |      CALL cgp_poly_elements_read_data_offsets_f(F, B, iZone, S, start_l, end_l, offsets_read, ierr)
      |                                                                                                   1
Error: Type mismatch in argument ‘end’ at (1); passed INTEGER(8) to INTEGER(4)
/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests/test_poly_unstructured_f90.F90:426:112:
  426 |      CALL cgp_poly_elements_read_data_elements_f(F, B, iZone, S, start_l, end_l, offsets_read, cells_read, ierr)
      |                                                                                                                1
Error: Type mismatch in argument ‘start’ at (1); passed INTEGER(8) to INTEGER(4)
/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests/test_poly_unstructured_f90.F90:426:112:
  426 |      CALL cgp_poly_elements_read_data_elements_f(F, B, iZone, S, start_l, end_l, offsets_read, cells_read, ierr)
      |                                                                                                                1
Error: Type mismatch in argument ‘end’ at (1); passed INTEGER(8) to INTEGER(4)
/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests/test_poly_unstructured_f90.F90:430:15:
  430 |      DO iCell = start_l, end_l
      |               1
Warning: Possible change of value in conversion from INTEGER(8) to INTEGER(4) at (1) [-Wconversion]
/builddir/build/BUILD/cgnslib-5.0.0-build/CGNS-3ff1d0b7ae4e41d442d2876c779b02e922165315/src/ptests/test_poly_unstructured_f90.F90:430:24:
  430 |      DO iCell = start_l, end_l
      |                        1
Warning: Possible change of value in conversion from INTEGER(8) to INTEGER(4) at (1) [-Wconversion]
```