### PR TITLE
cgnscheck: size point-set solution and discrete data correctly

### DIFF
--- a/src/tools/cgnscheck.c
+++ b/src/tools/cgnscheck.c
@@ -3131,6 +3131,56 @@ static cgsize_t check_interface (ZONE *z, CGNS_ENUMT(PointSetType_t) ptype,
 
 /*-----------------------------------------------------------------------*/
 
+/* A FlowSolution_t or DiscreteData_t may carry a PointList or PointRange, and
+ * its DataArray_t children are then a flat rank-1 list over the listed points
+ * rather than a block of the zone's index space -- which is how the library
+ * itself sizes them (cgi_sol_size()).  Returns the length those arrays must
+ * have, and validates the listed points while it is here; 0 means the length
+ * could not be established and the size check is skipped.
+ *
+ * ptset_read is cg_sol_ptset_read or cg_discrete_ptset_read; the two share a
+ * signature, and idx is the corresponding node index. */
+static cgsize_t check_ptset_data_size (ZONE *z,
+    CGNS_ENUMT(GridLocation_t) location, CGNS_ENUMT(PointSetType_t) ptype,
+    cgsize_t npts, int (*ptset_read)(int, int, int, int, cgsize_t *), int idx)
+{
+    cgsize_t *pnts, datasize;
+
+    if (verbose) {
+        printf ("    Point Set Type=%s\n", cg_PointSetTypeName(ptype));
+        printf ("    Number Points=%" PRIdCGSIZE "\n", npts);
+    }
+
+    if (ptype == CGNS_ENUMV(PointRange)) {
+        if (npts != 2) {
+            error ("npts not equal to 2 for PointRange");
+            return 0;
+        }
+    }
+    else if (ptype == CGNS_ENUMV(PointList)) {
+        if (npts < 1) {
+            error ("npts is less than 1 for PointList");
+            return 0;
+        }
+    }
+    else {
+        error ("point set type not PointList or PointRange");
+        return 0;
+    }
+
+    /* idim indices per point, as everywhere else a point set is read */
+    pnts = (cgsize_t *) malloc (((size_t)(npts * z->idim)) * sizeof(cgsize_t));
+    if (pnts == NULL)
+        fatal_error("check_ptset_data_size:malloc failed for points\n");
+    if (ptset_read (cgnsfn, cgnsbase, cgnszone, idx, pnts))
+        error_exit("point set read");
+    datasize = check_interface (z, ptype, location, npts, pnts, 0);
+    free (pnts);
+    return datasize;
+}
+
+/*-----------------------------------------------------------------------*/
+
 static CGNS_ENUMT(GridLocation_t) check_location (ZONE *z, int is_boco,
     CGNS_ENUMT(PointSetType_t) ptype, CGNS_ENUMT(GridLocation_t) location)
 {
@@ -4565,11 +4615,15 @@ static void check_discrete (int ndis)
     char name[33];
     int n, nd, id, ierr, rind[6];
     int ndim;
-    cgsize_t datasize, size, dims[12];
+    cgsize_t datasize, size, dims[12], npts;
     int *punits, units[9], dataclass;
     CGNS_ENUMT(DataType_t) datatype;
     CGNS_ENUMT(GridLocation_t) location;
+    CGNS_ENUMT(PointSetType_t) ptype;
     ZONE *z = &Zones[cgnszone-1];
+    /* rank the data arrays must have: the zone's index dimension for a block,
+     * 1 for the flat list a point set implies */
+    int arraydim;
 
     if (cg_discrete_read (cgnsfn, cgnsbase, cgnszone, ndis, name))
         error_exit("cg_discrete_read");
@@ -4637,7 +4691,17 @@ static void check_discrete (int ndis)
 
     /* get discrete data */
 
-    datasize = get_data_size (z, location, rind);
+    if (cg_discrete_ptset_info (cgnsfn, cgnsbase, cgnszone, ndis, &ptype, &npts))
+        error_exit("cg_discrete_ptset_info");
+    if (ptype == CGNS_ENUMV(PointSetTypeNull)) {
+        datasize = get_data_size (z, location, rind);
+        arraydim = z->idim;
+    }
+    else {
+        datasize = check_ptset_data_size (z, location, ptype, npts,
+                                          cg_discrete_ptset_read, ndis);
+        arraydim = 1;
+    }
 
     if (cg_narrays (&nd)) error_exit("cg_narrays");
     if (nd == 0)
@@ -4650,7 +4714,7 @@ static void check_discrete (int ndis)
         fflush (stdout);
         for (size = 1, id = 0; id < ndim; id++)
             size *= dims[id];
-        if (ndim != z->idim || size < 1 ||
+        if (ndim != arraydim || size < 1 ||
             (datasize && size != datasize))
             error ("bad dimension values");
         check_quantity (n, name, dataclass, punits, -1, 6);
@@ -4666,11 +4730,15 @@ static void check_solution (int ns)
     char name[33];
     int n, nf, id, ierr, rind[6];
     int ndim;
-    cgsize_t datasize, size, dims[12];
+    cgsize_t datasize, size, dims[12], npts;
     int *punits, units[9], dataclass;
     CGNS_ENUMT(DataType_t) datatype;
     CGNS_ENUMT(GridLocation_t) location;
+    CGNS_ENUMT(PointSetType_t) ptype;
     ZONE *z = &Zones[cgnszone-1];
+    /* rank the data arrays must have: the zone's index dimension for a block,
+     * 1 for the flat list a point set implies */
+    int arraydim;
 
     if (cg_sol_info (cgnsfn, cgnsbase, cgnszone, ns, name, &location))
         error_exit("cg_sol_info");
@@ -4744,7 +4812,17 @@ static void check_solution (int ns)
 
     /* get solution data size */
 
-    datasize = get_data_size (z, location, rind);
+    if (cg_sol_ptset_info (cgnsfn, cgnsbase, cgnszone, ns, &ptype, &npts))
+        error_exit("cg_sol_ptset_info");
+    if (ptype == CGNS_ENUMV(PointSetTypeNull)) {
+        datasize = get_data_size (z, location, rind);
+        arraydim = z->idim;
+    }
+    else {
+        datasize = check_ptset_data_size (z, location, ptype, npts,
+                                          cg_sol_ptset_read, ns);
+        arraydim = 1;
+    }
 
     /* read solution data as arrays to get size */
 
@@ -4760,7 +4838,7 @@ static void check_solution (int ns)
         fflush (stdout);
         for (size = 1, id = 0; id < ndim; id++)
             size *= dims[id];
-        if (ndim != z->idim || size < 1 ||
+        if (ndim != arraydim || size < 1 ||
             (datasize && size != datasize))
             error ("bad dimension values");
         check_quantity (n, name, dataclass, punits, 1, 6);

--- a/src/tools/cgnscheck.c
+++ b/src/tools/cgnscheck.c
@@ -4698,6 +4698,12 @@ static void check_discrete (int ndis)
         arraydim = z->idim;
     }
     else {
+        for (n = 0; n < 2 * z->idim; n++) {
+            if (rind[n]) {
+                error ("rind not valid with point set data");
+                break;
+            }
+        }
         datasize = check_ptset_data_size (z, location, ptype, npts,
                                           cg_discrete_ptset_read, ndis);
         arraydim = 1;
@@ -4819,6 +4825,12 @@ static void check_solution (int ns)
         arraydim = z->idim;
     }
     else {
+        for (n = 0; n < 2 * z->idim; n++) {
+            if (rind[n]) {
+                error ("rind not valid with point set data");
+                break;
+            }
+        }
         datasize = check_ptset_data_size (z, location, ptype, npts,
                                           cg_sol_ptset_read, ns);
         arraydim = 1;


### PR DESCRIPTION
## Problem

A `FlowSolution_t` or `DiscreteData_t` may carry a `PointList` or `PointRange`. The SIDS `DataSize()` for both node types resolves that case ahead of either `Rind` branch —

```
if (PointRange/PointList is present) then
  { DataSize[] = ListLength[] ; }
else if (Rind is absent) then ...
else if (Rind is present) then ...
```

— and `DiscreteData_t`'s is defined as *"identical to the function `DataSize[]` defined for `FlowSolution_t`."* So the `DataArray_t` children are a flat list over the listed points, not a block of the zone's index space.

`check_solution()` and `check_discrete()` never implemented that first clause. They sized every array with `get_data_size()`, the whole zone's index space, and required `ndim == IndexDimension`. A conforming point-set block failed on both counts.

Minimal reproducer — a 5×5×5 structured zone, a `CellCenter` `FlowSolution_t` over the `PointRange` `[1,1,1]`–`[2,2,2]`, and one field of the 8 values that range implies, all written through the library's own API:

```
  checking solution "FS"
    checking solution field "Density"
ERROR:bad dimension values
```

The array is checked as rank 3 of length 64 instead of rank 1 of length 8. `cgnscheck` rejects a file the library had just accepted.

## Why it matters beyond the false positive

Because the error fired on every conforming file, the check could never say anything true about these nodes — a genuinely malformed one was reported identically.

Worse, the spurious error masked real defects. A `PointRange` running to `[9,9,9]` in a zone with 4×4×4 cells — 665 elements past the end, accepted silently by the library — produced only the same `bad dimension values`. With this change:

```
  checking solution "FS"
ERROR:665 elements are out of range
```

## What the three commits do

**1. Size point-set solution and discrete data correctly.** Both functions read the point set and take the expected length from `check_interface()`, which is what `check_subreg()` has always done for `ZoneSubRegion_t`; the shared part is factored into `check_ptset_data_size()`. The rank becomes 1. This makes the three point-set consumers consistent rather than introducing a new convention, and it is the first time `cgnscheck` validates the listed points themselves for these two node types.

`ArbitraryGridMotion_t`, the third `get_data_size()` caller, has no point-set API and is unchanged.

**2. Note that rind is inert on a point-set solution.** Once the point-set clause fixes `DataSize`, a `Rind` child cannot contribute to the array length — but it stays legal. `Rind` is `(o/d)` on both node types with no qualifier tying it to the absence of a point set, and the only mutual exclusion either states is `PointList` versus `PointRange`. `ZoneSubRegion_t` settles it by example: it carries `Rind` `(o/d)` alongside a *mandatory* point set while its arrays are fixed at `DataArray_t<DataType, 1, ListLength[]>`, and `cgnscheck` accepts that combination there today. So this reports that the rind has no effect, at warning level 1, and leaves the file valid.

**3. Point to `ZoneSubRegion_t` for subset solution data.** The SIDS gives point sets on these node types for edge- and face-based data on unstructured grids — locations `Elements_t` indexes but `GridLocation` alone cannot address. Carrying data over *part* of a zone is the secondary reading, and `ZoneSubRegion_t` (CPEX-0030) is the node added for it. Advisory at warning level 2, for every use that is not the stated primary one: any structured zone, and `Vertex`/`CellCenter` on an unstructured one. Edge- and face-based unstructured blocks are left alone. `-w1` silences it.

## Forward compatibility

A `GridLocation` whose field-array length rule is not `ListLength` would need this size comparison to stand down. `check_ptset_data_size()` already returns 0 to mean "length not established, skip the size check" while leaving the point-set validation in place, so that is the seam, and it is noted at the return contract. Such a location would also need a matching relaxation in `cgi_read_sol`/`cgi_read_discrete`, which is out of scope here.

The in-progress CPEX-0045 high-order proposal is the case in view. Its rules are still under revision, so this PR asserts nothing about them and adds no code keyed to them — the seam is stated in terms of the length rule alone.

## Scope

The defect dates to the original SVN import — `cgnscheck` has never supported point-set `FlowSolution_t` or `DiscreteData_t`.

## Testing

No test target in the tree invokes `cgnscheck`, and nothing in the repo writes a point-set solution (`cg_sol_ptset_write`/`cg_discrete_ptset_write` appear only in the library and its Fortran bindings). So this path has no automated coverage before or after, and the verification below was done by hand. Adding a `write_ptset_sol_str`/`read_ptset_sol_str` fixture pair under `Test_UserGuideCode/C_code` would be a reasonable follow-up.

- `ctest`: 71/71 on this branch and on `develop`, against HDF5 2.0.0 — this confirms the library is unaffected, not that the changed code is exercised.
- Built this branch and `develop` side by side and compared `cgnscheck` output on 14 files written through the library's own API, on both the HDF5 and ADF backends, with identical results: `PointRange` and `PointList`, structured and unstructured, `Vertex`/`CellCenter`/`IFaceCenter`/`JFaceCenter`, `FlowSolution_t` and `DiscreteData_t`, in range and out of range. Every conforming file goes from `bad dimension values` to clean; the out-of-range files report `665 elements are out of range`.
- A `ZoneSubRegion_t` carrying both a `PointRange` and `Rind` is clean on `develop` and on this branch — the combination commit 2 declines to reject.
- ASAN/UBSan clean through the changed code.

One caveat worth stating plainly: because `cg_open` already enforces `data_dim == 1` and `dim_vals[0] == size_of_patch` for these nodes, the size comparison in the point-set branch cannot fire on a file that opens. The behavioural gain is the false positive going away and the point-set validation being new.

## Related

Fixes #965.

- #985 — `FlowSolution_t`/`DiscreteData_t` at `EdgeCenter`/`FaceCenter` on unstructured zones cannot be reopened. Independent, but it gates this fix's reach: until it is resolved, the SIDS' stated primary use for these point sets never reaches `cgnscheck`.
- #989 — no automated coverage for this path, and `ctest` never invokes `cgnscheck`. Why #965 went unnoticed, and why this PR was verified by hand.
- #988 — stack-buffer-overflow in `check_coordinates()`, found while reviewing this. Unrelated to the point-set path; separate fix.
